### PR TITLE
Gracefully handle out of memory

### DIFF
--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -267,6 +267,10 @@ size_t AsyncAbstractResponse::_ack(AsyncWebServerRequest *request, size_t len, u
       outLen = (remaining > space)?space:remaining;
     }
     uint8_t *buf = (uint8_t *)malloc(outLen);
+    if (!buf) {
+      // os_printf("_ack malloc %d failed\n", outLen);
+      return 0;
+    }
 
     if(_chunked){
       readLen = _fillBuffer(buf, outLen - 8);


### PR DESCRIPTION
This strategy seems to work for me and seems clearer and simpler than some sort of backoff algorithm.

I'm assuming that returning 0 will keep the request open. Could you check if https://github.com/me-no-dev/ESPAsyncWebServer/compare/master...andig:fix-lowmem?expand=1#diff-2bfef7483934cf6c10c5c03a8553d5b0R273 is correct? I'm only guessing here according to the rest of the code.

Without this fix I'm into crashes right away when serving multiple static files under load.