### PR TITLE
avoid client ID being 0

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -544,7 +544,7 @@ uint16_t AsyncWebSocketClient::remotePort() {
 AsyncWebSocket::AsyncWebSocket(String url)
   :_url(url)
   ,_clients(NULL)
-  ,_cNextId(0)
+  ,_cNextId(1)
 {
   _eventHandler = NULL;
 }


### PR DESCRIPTION
Prevent having clientID set to 0
When managing an array of different clientID, it's preferable to a valid
client not having it's ID set to 0, IE when looping thru client array, having ID to 0 could now mean that the table entry if free.