### PR TITLE
use uint8_t to store WebRequestMethod

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -52,8 +52,16 @@ class AsyncCallbackWebHandler;
 class AsyncResponseStream;
 
 typedef enum {
-  HTTP_ANY, HTTP_GET, HTTP_POST, HTTP_DELETE, HTTP_PUT, HTTP_PATCH, HTTP_HEAD, HTTP_OPTIONS
+  HTTP_GET     = 0b00000001,
+  HTTP_POST    = 0b00000010,
+  HTTP_DELETE  = 0b00000100,
+  HTTP_PUT     = 0b00001000,
+  HTTP_PATCH   = 0b00010000,
+  HTTP_HEAD    = 0b00100000,
+  HTTP_OPTIONS = 0b01000000,
+  HTTP_ANY     = 0b01111111,
 } WebRequestMethod;
+typedef uint8_t WebRequestMethodComposite;
 
 /*
  * PARAMETER :: Chainable object to hold GET/POST and FILE parameters
@@ -123,7 +131,7 @@ class AsyncWebServerRequest {
     uint8_t _parseState;
 
     uint8_t _version;
-    WebRequestMethod _method;
+    WebRequestMethodComposite _method;
     String _url;
     String _host;
     String _contentType;
@@ -181,7 +189,7 @@ class AsyncWebServerRequest {
 
     AsyncClient* client(){ return _client; }
     uint8_t version(){ return _version; }
-    WebRequestMethod method(){ return _method; }
+    WebRequestMethodComposite method(){ return _method; }
     String url(){ return _url; }
     String host(){ return _host; }
     String contentType(){ return _contentType; }
@@ -370,9 +378,9 @@ class AsyncWebServer {
     AsyncWebHandler& addHandler(AsyncWebHandler* handler);
 
     AsyncCallbackWebHandler& on(const char* uri, ArRequestHandlerFunction onRequest);
-    AsyncCallbackWebHandler& on(const char* uri, WebRequestMethod method, ArRequestHandlerFunction onRequest);
-    AsyncCallbackWebHandler& on(const char* uri, WebRequestMethod method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload);
-    AsyncCallbackWebHandler& on(const char* uri, WebRequestMethod method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload, ArBodyHandlerFunction onBody);
+    AsyncCallbackWebHandler& on(const char* uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest);
+    AsyncCallbackWebHandler& on(const char* uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload);
+    AsyncCallbackWebHandler& on(const char* uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload, ArBodyHandlerFunction onBody);
 
     AsyncStaticWebHandler& serveStatic(const char* uri, fs::FS& fs, const char* path, const char* cache_control = NULL);
 

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -59,14 +59,14 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
   private:
   protected:
     String _uri;
-    WebRequestMethod _method;
+    WebRequestMethodComposite _method;
     ArRequestHandlerFunction _onRequest;
     ArUploadHandlerFunction _onUpload;
     ArBodyHandlerFunction _onBody;
   public:
     AsyncCallbackWebHandler() : _uri(), _method(HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL){}
     void setUri(String uri){ _uri = uri; }
-    void setMethod(WebRequestMethod method){ _method = method; }
+    void setMethod(WebRequestMethodComposite method){ _method = method; }
     void onRequest(ArRequestHandlerFunction fn){ _onRequest = fn; }
     void onUpload(ArUploadHandlerFunction fn){ _onUpload = fn; }
     void onBody(ArBodyHandlerFunction fn){ _onBody = fn; }
@@ -75,7 +75,7 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
       if(!_onRequest)
         return false;
 
-      if(_method != HTTP_ANY && request->method() != _method)
+      if(!(_method & request->method()))
         return false;
 
       if(_uri.length() && (_uri != request->url() && !request->url().startsWith(_uri+"/")))

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -854,12 +854,12 @@ String AsyncWebServerRequest::urlDecode(const String& text){
 
 const char * AsyncWebServerRequest::methodToString(){
   if(_method == HTTP_ANY) return "ANY";
-  else if(_method == HTTP_GET) return "GET";
-  else if(_method == HTTP_POST) return "POST";
-  else if(_method == HTTP_DELETE) return "DELETE";
-  else if(_method == HTTP_PUT) return "PUT";
-  else if(_method == HTTP_PATCH) return "PATCH";
-  else if(_method == HTTP_HEAD) return "HEAD";
-  else if(_method == HTTP_OPTIONS) return "OPTIONS";
+  else if(_method & HTTP_GET) return "GET";
+  else if(_method & HTTP_POST) return "POST";
+  else if(_method & HTTP_DELETE) return "DELETE";
+  else if(_method & HTTP_PUT) return "PUT";
+  else if(_method & HTTP_PATCH) return "PATCH";
+  else if(_method & HTTP_HEAD) return "HEAD";
+  else if(_method & HTTP_OPTIONS) return "OPTIONS";
   return "UNKNOWN";
 }

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -115,7 +115,7 @@ void AsyncWebServer::_attachHandler(AsyncWebServerRequest *request){
 }
 
 
-AsyncCallbackWebHandler& AsyncWebServer::on(const char* uri, WebRequestMethod method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload, ArBodyHandlerFunction onBody){
+AsyncCallbackWebHandler& AsyncWebServer::on(const char* uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload, ArBodyHandlerFunction onBody){
   AsyncCallbackWebHandler* handler = new AsyncCallbackWebHandler();
   handler->setUri(uri);
   handler->setMethod(method);
@@ -126,7 +126,7 @@ AsyncCallbackWebHandler& AsyncWebServer::on(const char* uri, WebRequestMethod me
   return *handler;
 }
 
-AsyncCallbackWebHandler& AsyncWebServer::on(const char* uri, WebRequestMethod method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload){
+AsyncCallbackWebHandler& AsyncWebServer::on(const char* uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload){
   AsyncCallbackWebHandler* handler = new AsyncCallbackWebHandler();
   handler->setUri(uri);
   handler->setMethod(method);
@@ -136,7 +136,7 @@ AsyncCallbackWebHandler& AsyncWebServer::on(const char* uri, WebRequestMethod me
   return *handler;
 }
 
-AsyncCallbackWebHandler& AsyncWebServer::on(const char* uri, WebRequestMethod method, ArRequestHandlerFunction onRequest){
+AsyncCallbackWebHandler& AsyncWebServer::on(const char* uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest){
   AsyncCallbackWebHandler* handler = new AsyncCallbackWebHandler();
   handler->setUri(uri);
   handler->setMethod(method);


### PR DESCRIPTION
so we can have server.on("/foo", HTTP_GET | HTTP_POST,
[](AsyncWebServerRequest *request) {}) to handle multiple methods.

this also saves a bit memory, enums are stored in int, which is 32bit on
xtensa. since we only have 7 methods (plus HTTP_ANY for everything) we
only want 7 bit, so uint8_t is pretty sufficient.