### PR TITLE
added lower case string for 'Host'

### DIFF
--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -267,7 +267,7 @@ bool AsyncWebServerRequest::_parseReqHeader(){
   if(index){
     String name = _temp.substring(0, index);
     String value = _temp.substring(index + 2);
-    if(name == "Host"){
+    if(name == "Host" || name == "host"){
       _host = value;
       _server->_rewriteRequest(this);
       _server->_attachHandler(this);


### PR DESCRIPTION
The 'request' npm package generates headers with "host" i.s.o. "Host". 
Not sure who is wrong, but had to change WebRequest.cpp for this.