### PR TITLE
Fix const correctness of _sourceValid

### DIFF
--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -82,7 +82,7 @@ class AsyncEventSourceResponse: public AsyncWebServerResponse {
     AsyncEventSourceResponse(AsyncEventSource *server);
     void _respond(AsyncWebServerRequest *request);
     size_t _ack(AsyncWebServerRequest *request, size_t len, uint32_t time);
-    bool _sourceValid(){ return true; }
+    bool _sourceValid() const { return true; }
 };
 
 

--- a/src/AsyncJson.h
+++ b/src/AsyncJson.h
@@ -65,7 +65,7 @@ class AsyncJsonResponse: public AsyncAbstractResponse {
     }
     ~AsyncJsonResponse() {}
     JsonVariant & getRoot() { return _root; }
-    bool _sourceValid() { return _isValid; }
+    bool _sourceValid() const { return _isValid; }
     size_t setLength() {
       _contentLength = _root.measureLength();
       if (_contentLength) { _isValid = true; }

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -154,7 +154,7 @@ class AsyncWebSocketControl {
       if(_data != NULL)
         free(_data);
     }
-    virtual bool finished(){ return _finished; }
+    virtual bool finished() const { return _finished; }
     uint8_t opcode(){ return _opcode; }
     uint8_t len(){ return _len + 2; }
     size_t send(AsyncClient *client){

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -219,7 +219,7 @@ class AsyncWebSocketResponse: public AsyncWebServerResponse {
     AsyncWebSocketResponse(const String& key, AsyncWebSocket *server);
     void _respond(AsyncWebServerRequest *request);
     size_t _ack(AsyncWebServerRequest *request, size_t len, uint32_t time);
-    bool _sourceValid(){ return true; }
+    bool _sourceValid() const { return true; }
 };
 
 


### PR DESCRIPTION
In https://github.com/me-no-dev/ESPAsyncWebServer/commit/a7c4dfb04fd6a06001d9f87ba9935cc67cb256d5 the signature of the method `bool _sourceValid()` of `AsyncWebServerResponse` was changed to `bool _sourceValid() const`. However, the change wasn't applied to all implementations (e.g. `EventSource` and `WebSocket` responses) and the method wouldn't be overridden, causing it to return the default value `false`. Consequently, for example WebSocket responses would fail with an Internal Server Error because the method didn't return `true`.

This PR fixes the implementations of `AsyncWebServerResponse` to match the prototype.