### PR TITLE
Fix premture connection termination

### DIFF
--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -599,8 +599,10 @@ void AsyncWebServerRequest::send(AsyncWebServerResponse *response){
     _response = NULL;
     send(500);
   }
-  else
+  else {
+    _client->setRxTimeout(0);
     _response->_respond(this);
+  }
 }
 
 AsyncWebServerResponse * AsyncWebServerRequest::beginResponse(int code, const String& contentType, const String& content){


### PR DESCRIPTION
When request serving load is high, some response may get preempted for quite some time due to resource depletion. If the Rx timeout check is not disabled, the connection can terminate prematurely, causing client side to receive empty or truncated responses.