### PR TITLE
  flash string malloc memory leak

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -129,7 +129,7 @@ AsyncEventSourceMessage::~AsyncEventSourceMessage() {
 }
 
 void AsyncEventSourceMessage::ack(size_t len, uint32_t time) {
-  if(_len == len && _sent = _len){
+  if(_len == len && _sent == _len){
      _status = EVS_MSG_SENT;
   }
 }

--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -104,9 +104,53 @@ static String generateEventMessage(const char *message, const char *event, uint3
   return ev;
 }
 
+// Message
+
+AsyncEventSourceMessage::AsyncEventSourceMessage(const char * data, size_t len)
+: _status(EVS_MSG_ERROR), _data(nullptr), _len(len), _sent(0)
+{
+  _data = (uint8_t*)malloc(_len+1);
+  if(_data == NULL){
+    _len = 0;
+    _status = EVS_MSG_ERROR;
+  } else {
+    _status = EVS_MSG_SENDING;
+    memcpy(_data, data, len);
+    _data[_len] = 0;
+    String temp = data;
+  }
+
+  
+}
+
+AsyncEventSourceMessage::~AsyncEventSourceMessage() {
+     if(_data != NULL)
+        free(_data);
+}
+
+void AsyncEventSourceMessage::ack(size_t len, uint32_t time) {
+  if(_len == len && _sent = _len){
+     _status = EVS_MSG_SENT;
+  }
+}
+
+size_t AsyncEventSourceMessage::send(AsyncClient *client) {
+  if(!client->canSend()){
+    return 0;
+  }
+  if(client->space() < _len){
+    return 0;
+  }
+  size_t sent = client->write((const char *)_data, _len);
+  _sent = sent;
+  return sent; 
+}
+
 // Client
 
-AsyncEventSourceClient::AsyncEventSourceClient(AsyncWebServerRequest *request, AsyncEventSource *server){
+AsyncEventSourceClient::AsyncEventSourceClient(AsyncWebServerRequest *request, AsyncEventSource *server)
+: _messageQueue(LinkedList<AsyncEventSourceMessage *>([](AsyncEventSourceMessage *m){ delete  m; }))
+{
   _client = request->client();
   _server = server;
   _lastId = 0;
@@ -115,18 +159,49 @@ AsyncEventSourceClient::AsyncEventSourceClient(AsyncWebServerRequest *request, A
     
   _client->setRxTimeout(0);
   _client->onError(NULL, NULL);
-  _client->onAck(NULL, NULL);
-  _client->onPoll(NULL, NULL);
+  _client->onAck([](void *r, AsyncClient* c, size_t len, uint32_t time){ ((AsyncEventSourceClient*)(r))->_onAck(len, time); }, this);
+  _client->onPoll([](void *r, AsyncClient* c){ ((AsyncEventSourceClient*)(r))->_onPoll(); }, this);
   _client->onData(NULL, NULL);
-  _client->onTimeout([](void *r, AsyncClient* c __attribute__((unused)), uint32_t time){ ((AsyncEventSourceClient*)(r))->_onTimeout(time); }, this);
-  _client->onDisconnect([](void *r, AsyncClient* c){ ((AsyncEventSourceClient*)(r))->_onDisconnect(); delete c; }, this);
+  _client->onTimeout([this](void *r, AsyncClient* c __attribute__((unused)), uint32_t time){ ((AsyncEventSourceClient*)(r))->_onTimeout(time); }, this);
+  _client->onDisconnect([this](void *r, AsyncClient* c){ ((AsyncEventSourceClient*)(r))->_onDisconnect(); delete c; }, this);
+
   _server->_addClient(this);
   delete request;
 }
 
 AsyncEventSourceClient::~AsyncEventSourceClient(){
+   _messageQueue.free();
   close();
 }
+
+void AsyncEventSourceClient::_queueMessage(AsyncEventSourceMessage *dataMessage){
+  if(dataMessage == NULL)
+    return;
+  if(!connected()){
+    delete dataMessage;
+    return;
+  }
+
+  _messageQueue.add(dataMessage);
+
+  if(_client->canSend()) { _runQueue(); } 
+}
+
+void AsyncEventSourceClient::_onAck(size_t len, uint32_t time){
+
+  if(len && !_messageQueue.isEmpty()){
+    _messageQueue.front()->ack(len, time);
+  }
+
+  _runQueue();
+}
+
+void AsyncEventSourceClient::_onPoll(){
+  if(_client->canSend() && !_messageQueue.isEmpty()){
+    _runQueue();
+  }
+}
+
 
 void AsyncEventSourceClient::_onTimeout(uint32_t time __attribute__((unused))){
   _client->close(true);
@@ -143,18 +218,22 @@ void AsyncEventSourceClient::close(){
 }
 
 void AsyncEventSourceClient::write(const char * message, size_t len){
-  if(!_client->canSend()){
-    return;
-  }
-  if(_client->space() < len){
-    return;
-  }
-  _client->write(message, len);
+  _queueMessage(new AsyncEventSourceMessage(message, len));
 }
 
 void AsyncEventSourceClient::send(const char *message, const char *event, uint32_t id, uint32_t reconnect){
   String ev = generateEventMessage(message, event, id, reconnect);
-  write(ev.c_str(), ev.length());
+  _queueMessage(new AsyncEventSourceMessage(ev.c_str(), ev.length()));
+}
+
+void AsyncEventSourceClient::_runQueue(){
+  while(!_messageQueue.isEmpty() && _messageQueue.front()->finished()){
+    _messageQueue.remove(_messageQueue.front());
+  }
+
+  if(!_messageQueue.isEmpty()){
+    _messageQueue.front()->send(_client);
+  }
 }
 
 
@@ -210,8 +289,9 @@ void AsyncEventSource::send(const char *message, const char *event, uint32_t id,
 
   String ev = generateEventMessage(message, event, id, reconnect);
   for(const auto &c: _clients){
-    if(c->connected())
+    if(c->connected()) {
       c->write(ev.c_str(), ev.length());
+    }
   }
 }
 
@@ -255,3 +335,4 @@ size_t AsyncEventSourceResponse::_ack(AsyncWebServerRequest *request, size_t len
   }
   return 0;
 }
+

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -167,66 +167,81 @@ class AsyncWebSocketControl {
  * Basic Buffered Message
  */
 
-class AsyncWebSocketBasicMessage: public AsyncWebSocketMessage {
-  private:
-    uint8_t * _data;
-    size_t _len;
-    size_t _sent;
-    size_t _ack;
-    size_t _acked;
 
-  public:
-    AsyncWebSocketBasicMessage(const char * data, size_t len, uint8_t opcode=WS_TEXT, bool mask=false)
-      :_len(len)
-      ,_sent(0)
-      ,_ack(0)
-      ,_acked(0)
-    {
-      _opcode = opcode & 0x07;
-      _mask = mask;
-      _data = (uint8_t*)malloc(_len+1);
-      if(_data == NULL){
-        _len = 0;
-        _status = WS_MSG_ERROR;
-      } else {
-        _status = WS_MSG_SENDING;
-        memcpy(_data, data, _len);
-        _data[_len] = 0;
-      }
+AsyncWebSocketBasicMessage::AsyncWebSocketBasicMessage(const char * data, size_t len, uint8_t opcode, bool mask)
+  :_len(len)
+  ,_sent(0)
+  ,_ack(0)
+  ,_acked(0)
+{
+  _opcode = opcode & 0x07;
+  _mask = mask;
+  _data = (uint8_t*)malloc(_len+1);
+  if(_data == NULL){
+    _len = 0;
+    _status = WS_MSG_ERROR;
+  } else {
+    _status = WS_MSG_SENDING;
+    memcpy(_data, data, _len);
+    _data[_len] = 0;
+  }
+}
+AsyncWebSocketBasicMessage::AsyncWebSocketBasicMessage(uint8_t opcode, bool mask)
+  :_len(0)
+  ,_sent(0)
+  ,_ack(0)
+  ,_acked(0)
+{
+  _opcode = opcode & 0x07;
+  _mask = mask;
+  
+}
+
+AsyncWebSocketBasicMessage::~AsyncWebSocketBasicMessage() {
+  if(_data != NULL)
+    free(_data);
+}
+
+ void AsyncWebSocketBasicMessage::ack(size_t len, uint32_t time)  {
+  _acked += len;
+  if(_sent == _len && _acked == _ack){
+    _status = WS_MSG_SENT;
+  }
+}
+ size_t AsyncWebSocketBasicMessage::send(AsyncClient *client)  {
+  if(_status != WS_MSG_SENDING)
+    return 0;
+  if(_acked < _ack){
+    return 0;
+  }
+  if(_sent == _len){
+    if(_acked == _ack)
+      _status = WS_MSG_SENT;
+    return 0;
+  }
+  size_t window = webSocketSendFrameWindow(client);
+  size_t toSend = _len - _sent;
+  if(window < toSend) toSend = window;
+  bool final = ((toSend + _sent) == _len);
+  size_t sent = webSocketSendFrame(client, final, (_sent == 0)?_opcode:WS_CONTINUATION, _mask, (uint8_t*)(_data+_sent), toSend);
+  _sent += sent;
+  uint8_t headLen = ((sent < 126)?2:4)+(_mask*4);
+  _ack += sent + headLen;
+  return sent;
+}
+
+bool AsyncWebSocketBasicMessage::reserve(size_t size) { 
+  if (size) {
+    _data = (uint8_t*)malloc(size +1);
+    if (_data) {
+      memset(_data, 0, size); 
+      _len = size; 
+      _status = WS_MSG_SENDING;
+      return true; 
     }
-    virtual ~AsyncWebSocketBasicMessage() override {
-      if(_data != NULL)
-        free(_data);
-    }
-    virtual bool betweenFrames() const override { return _acked == _ack; }
-    virtual void ack(size_t len, uint32_t time) override {
-      _acked += len;
-      if(_sent == _len && _acked == _ack){
-        _status = WS_MSG_SENT;
-      }
-    }
-    virtual size_t send(AsyncClient *client) override {
-      if(_status != WS_MSG_SENDING)
-        return 0;
-      if(_acked < _ack){
-        return 0;
-      }
-      if(_sent == _len){
-        if(_acked == _ack)
-          _status = WS_MSG_SENT;
-        return 0;
-      }
-      size_t window = webSocketSendFrameWindow(client);
-      size_t toSend = _len - _sent;
-      if(window < toSend) toSend = window;
-      bool final = ((toSend + _sent) == _len);
-      size_t sent = webSocketSendFrame(client, final, (_sent == 0)?_opcode:WS_CONTINUATION, _mask, (uint8_t*)(_data+_sent), toSend);
-      _sent += sent;
-      uint8_t headLen = ((sent < 126)?2:4)+(_mask*4);
-      _ack += sent + headLen;
-      return sent;
-    }
-};
+  }
+  return false; 
+ }
 
 
 

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -546,6 +546,7 @@ void AsyncWebSocketClient::text(const __FlashStringHelper *data){
       message[b] = pgm_read_byte(p++);
     message[n] = 0;
     text(message, n);
+    free(message); 
   }
 }
 
@@ -571,6 +572,7 @@ void AsyncWebSocketClient::binary(const __FlashStringHelper *data, size_t len){
     for(size_t b=0; b<len; b++)
       message[b] = pgm_read_byte(p++);
     binary(message, len);
+    free(message); 
   }
 }
 

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -60,6 +60,24 @@ class AsyncWebSocketMessage {
     virtual bool betweenFrames() const { return false; }
 };
 
+class AsyncWebSocketBasicMessage: public AsyncWebSocketMessage {
+  private:
+    uint8_t * _data;
+    size_t _len;
+    size_t _sent;
+    size_t _ack;
+    size_t _acked;
+public:
+    AsyncWebSocketBasicMessage(const char * data, size_t len, uint8_t opcode=WS_TEXT, bool mask=false);
+    AsyncWebSocketBasicMessage(uint8_t opcode=WS_TEXT, bool mask=false);
+    virtual ~AsyncWebSocketBasicMessage() override;
+    virtual bool betweenFrames() const override { return _acked == _ack; }
+    virtual void ack(size_t len, uint32_t time) override ;
+    virtual size_t send(AsyncClient *client) override ;
+    uint8_t * buffer() { return _data; }
+    bool reserve(size_t size);
+};
+
 class AsyncWebSocketClient {
   private:
     AsyncClient *_client;


### PR DESCRIPTION
malloc is not freed when using web sockets F().

Red line demonstrate time of WS client connection.  Sketch sends large F() string every second. 

Free heap Before fix
<img width="1077" alt="screen shot 2017-02-21 at 10 22 58" src="https://cloud.githubusercontent.com/assets/10061736/23161214/31f0eff0-f821-11e6-9222-ae7a321f6cc4.png">
Free heap After fix
<img width="906" alt="screen shot 2017-02-21 at 10 26 38" src="https://cloud.githubusercontent.com/assets/10061736/23161221/392c9f9e-f821-11e6-9aa8-e95828996f76.png">
