### PR TITLE
Flash String support

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -228,21 +228,30 @@ class AsyncWebServerRequest {
 
     size_t headers() const;                     // get header count
     bool hasHeader(const String& name) const;   // check if header exists
+    bool hasHeader(const __FlashStringHelper * data) const;   // check if header exists
+
     AsyncWebHeader* getHeader(const String& name) const;
+    AsyncWebHeader* getHeader(const __FlashStringHelper * data) const;
     AsyncWebHeader* getHeader(size_t num) const;
 
     size_t params() const;                      // get arguments count
     bool hasParam(const String& name, bool post=false, bool file=false) const;
+    bool hasParam(const __FlashStringHelper * data, bool post=false, bool file=false) const;
+
     AsyncWebParameter* getParam(const String& name, bool post=false, bool file=false) const;
+    AsyncWebParameter* getParam(const __FlashStringHelper * data, bool post, bool file) const; 
     AsyncWebParameter* getParam(size_t num) const;
 
     size_t args() const { return params(); }     // get arguments count
     const String& arg(const String& name) const; // get request argument value by name
+    const String& arg(const __FlashStringHelper * data) const; // get request argument value by F(name)    
     const String& arg(size_t i) const;           // get request argument value by number
     const String& argName(size_t i) const;       // get request argument name by number
     bool hasArg(const char* name) const;         // check if argument exists
+    bool hasArg(const __FlashStringHelper * data) const;         // check if F(argument) exists
 
     const String& header(const char* name) const;// get request header value by name
+    const String& header(const __FlashStringHelper * data) const;// get request header value by F(name)    
     const String& header(size_t i) const;        // get request header value by number
     const String& headerName(size_t i) const;    // get request header name by number
     String urlDecode(const String& text) const;

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -541,6 +541,26 @@ bool AsyncWebServerRequest::hasHeader(const String& name) const {
   return false;
 }
 
+bool AsyncWebServerRequest::hasHeader(const __FlashStringHelper * data) const {
+  PGM_P p = reinterpret_cast<PGM_P>(data);
+  size_t n = 0;
+  while (1) {
+    if (pgm_read_byte(p+n) == 0) break;
+      n += 1;
+  }
+  char * name = (char*) malloc(n+1);
+  name[n] = 0; 
+  if (name) {
+    for(size_t b=0; b<n; b++)
+      name[b] = pgm_read_byte(p++);    
+    bool result = hasHeader( String(name) ); 
+    free(name); 
+    return result; 
+  } else {
+    return false; 
+  }
+}
+
 AsyncWebHeader* AsyncWebServerRequest::getHeader(const String& name) const {
   for(const auto& h: _headers){
     if(h->name().equalsIgnoreCase(name)){
@@ -548,6 +568,25 @@ AsyncWebHeader* AsyncWebServerRequest::getHeader(const String& name) const {
     }
   }
   return nullptr;
+}
+
+AsyncWebHeader* AsyncWebServerRequest::getHeader(const __FlashStringHelper * data) const {
+  PGM_P p = reinterpret_cast<PGM_P>(data);
+  size_t n = 0;
+  while (1) {
+    if (pgm_read_byte(p+n) == 0) break;
+      n += 1;
+  }
+  char * name = (char*) malloc(n+1);
+  if (name) {
+    for(size_t b=0; b<n; b++)
+      name[b] = pgm_read_byte(p++);    
+    AsyncWebHeader* result = getHeader( String(name)); 
+    free(name); 
+    return result; 
+  } else {
+    return nullptr; 
+  }
 }
 
 AsyncWebHeader* AsyncWebServerRequest::getHeader(size_t num) const {
@@ -568,6 +607,26 @@ bool AsyncWebServerRequest::hasParam(const String& name, bool post, bool file) c
   return false;
 }
 
+bool AsyncWebServerRequest::hasParam(const __FlashStringHelper * data, bool post, bool file) const {
+  PGM_P p = reinterpret_cast<PGM_P>(data);
+  size_t n = 0;
+  while (1) {
+    if (pgm_read_byte(p+n) == 0) break;
+      n += 1;
+  }
+  char * name = (char*) malloc(n+1);
+  name[n] = 0; 
+  if (name) {
+    for(size_t b=0; b<n; b++)
+      name[b] = pgm_read_byte(p++);    
+    bool result = hasParam( name, post, file); 
+    free(name); 
+    return result; 
+  } else {
+    return false; 
+  }
+}
+
 AsyncWebParameter* AsyncWebServerRequest::getParam(const String& name, bool post, bool file) const {
   for(const auto& p: _params){
     if(p->name() == name && p->isPost() == post && p->isFile() == file){
@@ -575,6 +634,26 @@ AsyncWebParameter* AsyncWebServerRequest::getParam(const String& name, bool post
     }
   }
   return nullptr;
+}
+
+AsyncWebParameter* AsyncWebServerRequest::getParam(const __FlashStringHelper * data, bool post, bool file) const {
+  PGM_P p = reinterpret_cast<PGM_P>(data);
+  size_t n = 0;
+  while (1) {
+    if (pgm_read_byte(p+n) == 0) break;
+      n += 1;
+  }
+  char * name = (char*) malloc(n+1);
+  name[n] = 0; 
+  if (name) {
+    for(size_t b=0; b<n; b++)
+      name[b] = pgm_read_byte(p++);    
+    AsyncWebParameter* result = getParam(name, post, file); 
+    free(name); 
+    return result; 
+  } else {
+    return nullptr; 
+  }
 }
 
 AsyncWebParameter* AsyncWebServerRequest::getParam(size_t num) const {
@@ -747,6 +826,27 @@ bool AsyncWebServerRequest::hasArg(const char* name) const {
   return false;
 }
 
+bool AsyncWebServerRequest::hasArg(const __FlashStringHelper * data) const {
+  PGM_P p = reinterpret_cast<PGM_P>(data);
+  size_t n = 0;
+  while (1) {
+    if (pgm_read_byte(p+n) == 0) break;
+      n += 1;
+  }
+  char * name = (char*) malloc(n+1);
+  name[n] = 0; 
+  if (name) {
+    for(size_t b=0; b<n; b++)
+      name[b] = pgm_read_byte(p++);    
+    bool result = hasArg( name ); 
+    free(name); 
+    return result; 
+  } else {
+    return false; 
+  }
+}
+
+
 const String& AsyncWebServerRequest::arg(const String& name) const {
   for(const auto& arg: _params){
     if(arg->name() == name){
@@ -754,6 +854,27 @@ const String& AsyncWebServerRequest::arg(const String& name) const {
     }
   }
   return SharedEmptyString;
+}
+
+const String& AsyncWebServerRequest::arg(const __FlashStringHelper * data) const {
+  PGM_P p = reinterpret_cast<PGM_P>(data);
+  size_t n = 0;
+  while (1) {
+    if (pgm_read_byte(p+n) == 0) break;
+      n += 1;
+  }
+  char * name = (char*) malloc(n+1);
+  name[n] = 0; 
+  if (name) {
+    for(size_t b=0; b<n; b++)
+      name[b] = pgm_read_byte(p++);    
+    const String & result = arg( String(name) ); 
+    free(name); 
+    return result; 
+  } else {
+    return SharedEmptyString;
+  }
+
 }
 
 const String& AsyncWebServerRequest::arg(size_t i) const {
@@ -768,6 +889,27 @@ const String& AsyncWebServerRequest::header(const char* name) const {
   AsyncWebHeader* h = getHeader(String(name));
   return h ? h->value() : SharedEmptyString;
 }
+
+const String& AsyncWebServerRequest::header(const __FlashStringHelper * data) const {
+  PGM_P p = reinterpret_cast<PGM_P>(data);
+  size_t n = 0;
+  while (1) {
+    if (pgm_read_byte(p+n) == 0) break;
+      n += 1;
+  }
+  char * name = (char*) malloc(n+1);
+  name[n] = 0; 
+  if (name) {
+    for(size_t b=0; b<n; b++)
+      name[b] = pgm_read_byte(p++);    
+    const String & result = header( (const char *)name ); 
+    free(name); 
+    return result; 
+  } else {
+    return SharedEmptyString; 
+  }
+};  
+
 
 const String& AsyncWebServerRequest::header(size_t i) const {
   AsyncWebHeader* h = getHeader(i);

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -572,15 +572,10 @@ AsyncWebHeader* AsyncWebServerRequest::getHeader(const String& name) const {
 
 AsyncWebHeader* AsyncWebServerRequest::getHeader(const __FlashStringHelper * data) const {
   PGM_P p = reinterpret_cast<PGM_P>(data);
-  size_t n = 0;
-  while (1) {
-    if (pgm_read_byte(p+n) == 0) break;
-      n += 1;
-  }
+  size_t n = strlen_P(p); 
   char * name = (char*) malloc(n+1);
   if (name) {
-    for(size_t b=0; b<n; b++)
-      name[b] = pgm_read_byte(p++);    
+    strcpy_P(name, p); 
     AsyncWebHeader* result = getHeader( String(name)); 
     free(name); 
     return result; 
@@ -609,16 +604,12 @@ bool AsyncWebServerRequest::hasParam(const String& name, bool post, bool file) c
 
 bool AsyncWebServerRequest::hasParam(const __FlashStringHelper * data, bool post, bool file) const {
   PGM_P p = reinterpret_cast<PGM_P>(data);
-  size_t n = 0;
-  while (1) {
-    if (pgm_read_byte(p+n) == 0) break;
-      n += 1;
-  }
+  size_t n = strlen_P(p);
+
   char * name = (char*) malloc(n+1);
   name[n] = 0; 
   if (name) {
-    for(size_t b=0; b<n; b++)
-      name[b] = pgm_read_byte(p++);    
+    strcpy_P(name,p);    
     bool result = hasParam( name, post, file); 
     free(name); 
     return result; 
@@ -638,16 +629,10 @@ AsyncWebParameter* AsyncWebServerRequest::getParam(const String& name, bool post
 
 AsyncWebParameter* AsyncWebServerRequest::getParam(const __FlashStringHelper * data, bool post, bool file) const {
   PGM_P p = reinterpret_cast<PGM_P>(data);
-  size_t n = 0;
-  while (1) {
-    if (pgm_read_byte(p+n) == 0) break;
-      n += 1;
-  }
+  size_t n = strlen_P(p);
   char * name = (char*) malloc(n+1);
-  name[n] = 0; 
   if (name) {
-    for(size_t b=0; b<n; b++)
-      name[b] = pgm_read_byte(p++);    
+    strcpy_P(name, p);   
     AsyncWebParameter* result = getParam(name, post, file); 
     free(name); 
     return result; 
@@ -828,16 +813,10 @@ bool AsyncWebServerRequest::hasArg(const char* name) const {
 
 bool AsyncWebServerRequest::hasArg(const __FlashStringHelper * data) const {
   PGM_P p = reinterpret_cast<PGM_P>(data);
-  size_t n = 0;
-  while (1) {
-    if (pgm_read_byte(p+n) == 0) break;
-      n += 1;
-  }
+  size_t n = strlen_P(p); 
   char * name = (char*) malloc(n+1);
-  name[n] = 0; 
   if (name) {
-    for(size_t b=0; b<n; b++)
-      name[b] = pgm_read_byte(p++);    
+    strcpy_P(name, p);    
     bool result = hasArg( name ); 
     free(name); 
     return result; 
@@ -858,16 +837,10 @@ const String& AsyncWebServerRequest::arg(const String& name) const {
 
 const String& AsyncWebServerRequest::arg(const __FlashStringHelper * data) const {
   PGM_P p = reinterpret_cast<PGM_P>(data);
-  size_t n = 0;
-  while (1) {
-    if (pgm_read_byte(p+n) == 0) break;
-      n += 1;
-  }
+  size_t n = strlen_P(p);
   char * name = (char*) malloc(n+1);
-  name[n] = 0; 
   if (name) {
-    for(size_t b=0; b<n; b++)
-      name[b] = pgm_read_byte(p++);    
+    strcpy(name, p);   
     const String & result = arg( String(name) ); 
     free(name); 
     return result; 
@@ -892,16 +865,10 @@ const String& AsyncWebServerRequest::header(const char* name) const {
 
 const String& AsyncWebServerRequest::header(const __FlashStringHelper * data) const {
   PGM_P p = reinterpret_cast<PGM_P>(data);
-  size_t n = 0;
-  while (1) {
-    if (pgm_read_byte(p+n) == 0) break;
-      n += 1;
-  }
+  size_t n = strlen_P(p); 
   char * name = (char*) malloc(n+1);
-  name[n] = 0; 
   if (name) {
-    for(size_t b=0; b<n; b++)
-      name[b] = pgm_read_byte(p++);    
+    strcpy_P(name, p);  
     const String & result = header( (const char *)name ); 
     free(name); 
     return result; 


### PR DESCRIPTION
Adds Flash String support `F("xyzzy")` to common request functions. 

```cpp
    bool hasHeader(const __FlashStringHelper * data) const;   // check if header exists
    AsyncWebHeader* getHeader(const __FlashStringHelper * data) const;
    bool hasParam(const __FlashStringHelper * data, bool post=false, bool file=false) const;
    AsyncWebParameter* getParam(const __FlashStringHelper * data, bool post, bool file) const; 
    const String& arg(const __FlashStringHelper * data) const; // get request argument value by F(name)    
    bool hasArg(const __FlashStringHelper * data) const;         // check if F(argument) exists
    const String& header(const __FlashStringHelper * data) const;// get request header value by F(name)   
```

tested using 

```cpp
server.on("/test", HTTP_GET, [](AsyncWebServerRequest *request){
  if (request->hasHeader(F("header1"))) {
    Serial.println("hasHeader(const __FlashStringHelper * data) works");

    AsyncWebHeader* head = request->getHeader(F("header1")); 

    if (head) {
      Serial.println("getHeader(const __FlashStringHelper * data) works");
    }else {
      Serial.println("error"); 
    }
  }

  if (request->hasParam(F("param1"))) {
    Serial.println("hasParam(const __FlashStringHelper * data");

      AsyncWebParameter* param = request->getParam(F("param1")); 

        if (param) {
      Serial.println("getParam((const __FlashStringHelper * data) works");
    }  else {
      Serial.println("error"); 
    }
    
  }
  
  if (request->hasArg(F("arg1"))) {
    Serial.println("hasArg(const __FlashStringHelper * data");

      String arg = request->arg(F("arg1")); 

        if (arg.length()) {
      Serial.println("arg((const __FlashStringHelper * data) works");
    }  else {
      Serial.println("error"); 
    }
    
  }
 
    request->send(200);
  });

```