### PR TITLE
Web Sockets memory improvements : shared message buffer, direct buffer access

### DIFF
--- a/README.md
+++ b/README.md
@@ -790,6 +790,32 @@ const uint8_t flash_binary[] PROGMEM = { 0x01, 0x02, 0x03, 0x04 };
 client->binary(flash_binary, 4);
 ```
 
+### Direct access to web socket message buffer
+When sending a web socket message using the above methods a buffer is created.  Under certain circumstances you might want to manipulate or populate this buffer directly from your application, for example to prevent unnecessary duplications of the data.  This example below shows how to create a buffer and print data to it from an ArduinoJson object then send it.   
+
+```cpp
+void sendDataWs(AsyncWebSocketClient * client)
+{
+    DynamicJsonBuffer jsonBuffer;
+    JsonObject& root = jsonBuffer.createObject();
+    root["a"] = "abc";
+    root["b"] = "abcd";
+    root["c"] = "abcde";
+    root["d"] = "abcdef";
+    root["e"] = "abcdefg";
+    size_t len = root.measureLength();
+    AsyncWebSocketMessageBuffer * buffer = ws.makeBuffer(len); //  creates a buffer (len + 1) for you.
+    if (buffer) {
+        root.printTo((char *)buffer->get(), len + 1);
+        if (client) {
+            client->text(buffer);
+        } else {
+            ws.textAll(buffer);
+        }
+    }
+}
+```
+
 ## Async Event Source Plugin
 The server includes EventSource (Server-Sent Events) plugin which can be used to send short text events to the browser.
 Difference between EventSource and WebSockets is that EventSource is single direction, text-only protocol.

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -46,6 +46,34 @@ typedef enum { WS_CONTINUATION, WS_TEXT, WS_BINARY, WS_DISCONNECT = 0x08, WS_PIN
 typedef enum { WS_MSG_SENDING, WS_MSG_SENT, WS_MSG_ERROR } AwsMessageStatus;
 typedef enum { WS_EVT_CONNECT, WS_EVT_DISCONNECT, WS_EVT_PONG, WS_EVT_ERROR, WS_EVT_DATA } AwsEventType;
 
+class AsyncWebSocketMessageBuffer {
+  private:
+    uint8_t * _data;
+    size_t _len;
+    bool _lock; 
+    uint32_t _count;  
+
+  public:
+    AsyncWebSocketMessageBuffer();
+    AsyncWebSocketMessageBuffer(size_t size);
+    AsyncWebSocketMessageBuffer(uint8_t * data, size_t size); 
+    AsyncWebSocketMessageBuffer(const AsyncWebSocketMessageBuffer &); 
+    AsyncWebSocketMessageBuffer(AsyncWebSocketMessageBuffer &&); 
+    ~AsyncWebSocketMessageBuffer(); 
+    void operator ++(int i) { _count++; }
+    void operator --(int i) {  if (_count > 0) { _count--; } ;  }
+    bool reserve(size_t size);
+    void lock() { _lock = true; }
+    void unlock() { _lock = false; }
+    uint8_t * get() { return _data; }
+    size_t length() { return _len; }
+    uint32_t count() { return _count; }
+    bool canDelete() { return (!_count && !_lock); } 
+
+    friend AsyncWebSocket; 
+
+};
+
 class AsyncWebSocketMessage {
   protected:
     uint8_t _opcode;
@@ -58,6 +86,38 @@ class AsyncWebSocketMessage {
     virtual size_t send(AsyncClient *client __attribute__((unused))){ return 0; }
     virtual bool finished(){ return _status != WS_MSG_SENDING; }
     virtual bool betweenFrames() const { return false; }
+};
+
+class AsyncWebSocketBasicMessage: public AsyncWebSocketMessage {
+  private:
+    uint8_t * _data;
+    size_t _len;
+    size_t _sent;
+    size_t _ack;
+    size_t _acked;
+public:
+    AsyncWebSocketBasicMessage(const char * data, size_t len, uint8_t opcode=WS_TEXT, bool mask=false);
+    AsyncWebSocketBasicMessage(uint8_t opcode=WS_TEXT, bool mask=false);
+    virtual ~AsyncWebSocketBasicMessage() override;
+    virtual bool betweenFrames() const override { return _acked == _ack; }
+    virtual void ack(size_t len, uint32_t time) override ;
+    virtual size_t send(AsyncClient *client) override ;
+};
+
+class AsyncWebSocketMultiMessage: public AsyncWebSocketMessage {
+  private:
+    uint8_t * _data;
+    size_t _len;
+    size_t _sent;
+    size_t _ack;
+    size_t _acked;
+    AsyncWebSocketMessageBuffer * _WSbuffer; 
+public:
+    AsyncWebSocketMultiMessage(AsyncWebSocketMessageBuffer * buffer, uint8_t opcode=WS_TEXT, bool mask=false); 
+    virtual ~AsyncWebSocketMultiMessage() override;
+    virtual bool betweenFrames() const override { return _acked == _ack; }
+    virtual void ack(size_t len, uint32_t time) override ;
+    virtual size_t send(AsyncClient *client) override ;
 };
 
 class AsyncWebSocketClient {
@@ -116,6 +176,7 @@ class AsyncWebSocketClient {
     void text(char * message);
     void text(const String &message);
     void text(const __FlashStringHelper *data);
+    void text(AsyncWebSocketMessageBuffer *buffer); 
 
     void binary(const char * message, size_t len);
     void binary(const char * message);
@@ -123,6 +184,7 @@ class AsyncWebSocketClient {
     void binary(char * message);
     void binary(const String &message);
     void binary(const __FlashStringHelper *data, size_t len);
+    void binary(AsyncWebSocketMessageBuffer *buffer); 
 
     //system callbacks (do not call)
     void _onAck(size_t len, uint32_t time);
@@ -158,7 +220,7 @@ class AsyncWebSocket: public AsyncWebHandler {
     void closeAll(uint16_t code=0, const char * message=NULL);
 
     void ping(uint32_t id, uint8_t *data=NULL, size_t len=0);
-    void pingAll(uint8_t *data=NULL, size_t len=0);
+    void pingAll(uint8_t *data=NULL, size_t len=0); //  done
 
     void text(uint32_t id, const char * message, size_t len);
     void text(uint32_t id, const char * message);
@@ -172,7 +234,8 @@ class AsyncWebSocket: public AsyncWebHandler {
     void textAll(uint8_t * message, size_t len);
     void textAll(char * message);
     void textAll(const String &message);
-    void textAll(const __FlashStringHelper *message);
+    void textAll(const __FlashStringHelper *message); //  need to convert
+    void textAll(AsyncWebSocketMessageBuffer * buffer); 
 
     void binary(uint32_t id, const char * message, size_t len);
     void binary(uint32_t id, const char * message);
@@ -187,9 +250,10 @@ class AsyncWebSocket: public AsyncWebHandler {
     void binaryAll(char * message);
     void binaryAll(const String &message);
     void binaryAll(const __FlashStringHelper *message, size_t len);
+    void binaryAll(AsyncWebSocketMessageBuffer * buffer); 
 
     void message(uint32_t id, AsyncWebSocketMessage *message);
-    void messageAll(AsyncWebSocketMessage *message);
+    void messageAll(AsyncWebSocketMultiMessage *message);
 
     size_t printf(uint32_t id, const char *format, ...)  __attribute__ ((format (printf, 3, 4)));
     size_t printfAll(const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
@@ -208,6 +272,13 @@ class AsyncWebSocket: public AsyncWebHandler {
     void _handleEvent(AsyncWebSocketClient * client, AwsEventType type, void * arg, uint8_t *data, size_t len);
     virtual bool canHandle(AsyncWebServerRequest *request) override final;
     virtual void handleRequest(AsyncWebServerRequest *request) override final;
+
+
+    //  messagebuffer functions/objects. 
+    AsyncWebSocketMessageBuffer * makeBuffer(size_t size = 0); 
+    AsyncWebSocketMessageBuffer * makeBuffer(uint8_t * data, size_t size); 
+    LinkedList<AsyncWebSocketMessageBuffer *> _buffers;
+    void _cleanBuffers(); 
 };
 
 //WebServer response to authenticate the socket and detach the tcp client from the web server request


### PR DESCRIPTION
…messages to multiple clients.

Add ability to create a WS buffer directly and write to it, saving duplication of message in RAM, then send it.  example below is an arduinoJson message.

```cpp
void sendDataWs(AsyncWebSocketClient * client)
{
    DynamicJsonBuffer jsonBuffer;
    JsonObject& root = jsonBuffer.createObject();
    root["a"] = "abc";
    root["b"] = "abcd";
    root["c"] = "abcde";
    root["d"] = "abcdef";
    root["e"] = "abcdefg";
    size_t len = root.measureLength();
    AsyncWebSocketMessageBuffer * buffer = ws.makeBuffer(len); //  creates a buffer (len + 1) for you.
    if (buffer) {
        root.printTo((char *)buffer->get(), len + 1);
        if (client) {
            client->text(buffer);
        } else {
            ws.textAll(buffer);
        }
    }
}
```