### PR TITLE
Solve error "previous definition of 'class fs::File'"

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -116,6 +116,8 @@ class AsyncWebHeader {
 typedef std::function<size_t(uint8_t*, size_t, size_t)> AwsResponseFiller;
 
 class AsyncWebServerRequest {
+  using File = fs::File;
+  using FS = fs::FS;
   friend class AsyncWebServer;
   private:
     AsyncClient* _client;

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -26,6 +26,8 @@
 #include <time.h>
 
 class AsyncStaticWebHandler: public AsyncWebHandler {
+   using File = fs::File;
+   using FS = fs::FS;
   private:
     bool _getFile(AsyncWebServerRequest *request);
     bool _fileExists(AsyncWebServerRequest *request, const String& path);

--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -42,6 +42,8 @@ class AsyncAbstractResponse: public AsyncWebServerResponse {
 };
 
 class AsyncFileResponse: public AsyncAbstractResponse {
+  using File = fs::File;
+  using FS = fs::FS;
   private:
     File _content;
     String _path;


### PR DESCRIPTION
Solve error `previous definition of 'class fs::File` as per https://github.com/me-no-dev/ESPAsyncWebServer/issues/111#issuecomment-288265916 by @boblemaire