### PR TITLE
Fixing compiler warnings exposed with -Wall and -Wextra

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -339,7 +339,7 @@ AsyncWebSocketBasicMessage::~AsyncWebSocketBasicMessage() {
   size_t toSend = _len - _sent;
   if(window < toSend) toSend = window;
   bool final = ((toSend + _sent) == _len);
-  size_t sent = webSocketSendFrame(client, final, (_sent == 0)?_opcode:WS_CONTINUATION, _mask, (uint8_t*)(_data+_sent), toSend);
+  size_t sent = webSocketSendFrame(client, final, (_sent == 0)?_opcode:(int)WS_CONTINUATION, _mask, (uint8_t*)(_data+_sent), toSend);
   _sent += sent;
   uint8_t headLen = ((sent < 126)?2:4)+(_mask*4);
   _ack += sent + headLen;
@@ -416,7 +416,7 @@ AsyncWebSocketMultiMessage::~AsyncWebSocketMultiMessage() {
   size_t toSend = _len - _sent;
   if(window < toSend) toSend = window;
   bool final = ((toSend + _sent) == _len);
-  size_t sent = webSocketSendFrame(client, final, (_sent == 0)?_opcode:WS_CONTINUATION, _mask, (uint8_t*)(_data+_sent), toSend);
+  size_t sent = webSocketSendFrame(client, final, (_sent == 0)?_opcode:(int)WS_CONTINUATION, _mask, (uint8_t*)(_data+_sent), toSend);
   _sent += sent;
   uint8_t headLen = ((sent < 126)?2:4)+(_mask*4);
   _ack += sent + headLen;

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -306,7 +306,7 @@ class AsyncWebHandler {
   public:
     AsyncWebHandler():_username(""), _password(""){}
     AsyncWebHandler& setFilter(ArRequestFilterFunction fn) { _filter = fn; return *this; }
-    AsyncWebHandler& setAuthentication(const char *username, const char *password){  _username = String(username);_password = String(password);};
+    AsyncWebHandler& setAuthentication(const char *username, const char *password){  _username = String(username);_password = String(password); return *this; };
     bool filter(AsyncWebServerRequest *request){ return _filter == NULL || _filter(request); }
     virtual ~AsyncWebHandler(){}
     virtual bool canHandle(AsyncWebServerRequest *request __attribute__((unused))){


### PR DESCRIPTION
AsyncWebHandler::setAuthentication: return is required.
AsyncWebSocketMultiMessage::~AsyncWebSocketMultiMessage: error: enumeral and non-enumeral type in conditional expression.