### PR TITLE
Added onDisconnect

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -315,6 +315,7 @@ class AsyncWebHandler {
     virtual void handleRequest(AsyncWebServerRequest *request __attribute__((unused))){}
     virtual void handleUpload(AsyncWebServerRequest *request  __attribute__((unused)), const String& filename __attribute__((unused)), size_t index __attribute__((unused)), uint8_t *data __attribute__((unused)), size_t len __attribute__((unused)), bool final  __attribute__((unused))){}
     virtual void handleBody(AsyncWebServerRequest *request __attribute__((unused)), uint8_t *data __attribute__((unused)), size_t len __attribute__((unused)), size_t index __attribute__((unused)), size_t total __attribute__((unused))){}
+    virtual void handleDisconnect(AsyncWebServerRequest *request __attribute__((unused))){}
 };
 
 /*
@@ -363,6 +364,7 @@ class AsyncWebServerResponse {
 typedef std::function<void(AsyncWebServerRequest *request)> ArRequestHandlerFunction;
 typedef std::function<void(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final)> ArUploadHandlerFunction;
 typedef std::function<void(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total)> ArBodyHandlerFunction;
+typedef std::function<void(AsyncWebServerRequest *request)> ArDisconnectHandlerFunction;
 
 class AsyncWebServer {
   protected:

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -65,13 +65,15 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
     ArRequestHandlerFunction _onRequest;
     ArUploadHandlerFunction _onUpload;
     ArBodyHandlerFunction _onBody;
+    ArDisconnectHandlerFunction _onDisconnect;
   public:
-    AsyncCallbackWebHandler() : _uri(), _method(HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL){}
+    AsyncCallbackWebHandler() : _uri(), _method(HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL), _onDisconnect(NULL){}
     void setUri(const String& uri){ _uri = uri; }
     void setMethod(WebRequestMethodComposite method){ _method = method; }
     void onRequest(ArRequestHandlerFunction fn){ _onRequest = fn; }
     void onUpload(ArUploadHandlerFunction fn){ _onUpload = fn; }
     void onBody(ArBodyHandlerFunction fn){ _onBody = fn; }
+    void onDisconnect(ArDisconnectHandlerFunction fn){ _onDisconnect = fn; }
 
     virtual bool canHandle(AsyncWebServerRequest *request) override final{
 
@@ -101,6 +103,10 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
     virtual void handleBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) override final {
       if(_onBody)
         _onBody(request, data, len, index, total);
+    }
+    virtual void handleDisconnect(AsyncWebServerRequest *request) override final {
+      if(_onDisconnect)
+        _onDisconnect(request);
     }
 };
 

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -196,6 +196,7 @@ void AsyncWebServerRequest::_onTimeout(uint32_t time){
 
 void AsyncWebServerRequest::_onDisconnect(){
   //os_printf("d\n");
+  if(_handler) _handler->handleDisconnect(this);
   _server->_handleDisconnect(this);
 }
 


### PR DESCRIPTION
I've added an "onDisconnect" handler to the AsyncCallbackWebHandler class. The reasoning behind this is when uploading content as part of the request body, resources may need to be allocated to handle this. But if the upload terminates early there was no way to free those resources (well, none that I could idenitfy).

With this patch I can now do this:

```
webserver.on("/write", HTTP_POST, [](AsyncWebServerRequest *request) {
        // handle request
    }, NULL, [](AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
        // allocate resources
    }).onDisconnect([](AsyncWebServerRequest *request) {
        // free resources
    });
```

and know that the "onDisconnect" method will always be called, even on error.