### PR TITLE
Added simple template processor to AsyncFileResponse. Optimized chunked responses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ To use this library you might need to have the latest git versions of [ESP8266](
 		- [Respond with content coming from a Stream and extra headers](#respond-with-content-coming-from-a-stream-and-extra-headers)
 		- [Respond with content coming from a File](#respond-with-content-coming-from-a-file)
 		- [Respond with content coming from a File and extra headers](#respond-with-content-coming-from-a-file-and-extra-headers)
+		- [Respond with content coming from a File containing templates](#respond-with-content-coming-from-a-file-containing-templates)
 		- [Respond with content using a callback](#respond-with-content-using-a-callback)
 		- [Respond with content using a callback and extra headers](#respond-with-content-using-a-callback-and-extra-headers)
 		- [Chunked Response](#chunked-response)
@@ -48,6 +49,7 @@ To use this library you might need to have the latest git versions of [ESP8266](
 		- [Serving files in directory](#serving-files-in-directory)
 		- [Specifying Cache-Control header](#specifying-cache-control-header)
 		- [Specifying Date-Modified header](#specifying-date-modified-header)
+		- [Specifying Template Processor callback](#specifying-template-processor-callback)
 	- [Using filters](#using-filters)
 		- [Serve different site files in AP mode](#serve-different-site-files-in-ap-mode)
 		- [Rewrite to different index on AP](#rewrite-to-different-index-on-ap)
@@ -410,6 +412,31 @@ response->addHeader("Server","ESP Async Web Server");
 request->send(response);
 ```
 
+### Respond with content coming from a File containing templates
+Internally uses [Chunked Response](#chunked-response).
+
+Index.htm contents:
+```
+%HELLO_FROM_TEMPLATE%
+```
+
+Somewhere in source files:
+```cpp
+String processor(const String& var)
+{
+  if(var == "HELLO_FROM_TEMPLATE")
+    return F("Hello world!");
+  return String();
+}
+
+// ...
+
+//Send index.htm with template processor function
+AsyncWebServerResponse *response = request->beginResponse(SPIFFS, "/index.htm", String(), false, processor);
+
+request->send(response);
+```
+
 ### Respond with content using a callback
 ```cpp
 //send 128 bytes as plain text
@@ -608,6 +635,23 @@ String date_modified = getNewDateModfied();
 saveDateModified(date_modified); // Save for next reset
 handler->setLastModified(date_modified);
 ```
+
+### Specifying Template Processor callback
+It is possible to specify template processor for static files. For information on template processor see
+[Respond with content coming from a File containing templates](#respond-with-content-coming-from-a-file-containing-templates).
+```cpp
+String processor(const String& var)
+{
+  if(var == "HELLO_FROM_TEMPLATE")
+    return F("Hello world!");
+  return String();
+}
+
+// ...
+
+server.serveStatic("/", SPIFFS, "/www/").setTemplateProcessor(processor);
+```
+
 
 ## Using filters
 Filters can be set to `Rewrite` or `Handler` in order to control when to apply the rewrite and consider the handler.

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -114,6 +114,7 @@ class AsyncWebHeader {
  * */
 
 typedef std::function<size_t(uint8_t*, size_t, size_t)> AwsResponseFiller;
+typedef std::function<String(const String&)> AwsTemplateProcessor;
 
 class AsyncWebServerRequest {
   using File = fs::File;
@@ -210,8 +211,8 @@ class AsyncWebServerRequest {
 
     void send(AsyncWebServerResponse *response);
     void send(int code, const String& contentType=String(), const String& content=String());
-    void send(FS &fs, const String& path, const String& contentType=String(), bool download=false);
-    void send(File content, const String& path, const String& contentType=String(), bool download=false);
+    void send(FS &fs, const String& path, const String& contentType=String(), bool download=false, AwsTemplateProcessor callback=nullptr);
+    void send(File content, const String& path, const String& contentType=String(), bool download=false, AwsTemplateProcessor callback=nullptr);
     void send(Stream &stream, const String& contentType, size_t len);
     void send(const String& contentType, size_t len, AwsResponseFiller callback);
     void sendChunked(const String& contentType, AwsResponseFiller callback);
@@ -219,8 +220,8 @@ class AsyncWebServerRequest {
     void send_P(int code, const String& contentType, PGM_P content);
 
     AsyncWebServerResponse *beginResponse(int code, const String& contentType=String(), const String& content=String());
-    AsyncWebServerResponse *beginResponse(FS &fs, const String& path, const String& contentType=String(), bool download=false);
-    AsyncWebServerResponse *beginResponse(File content, const String& path, const String& contentType=String(), bool download=false);
+    AsyncWebServerResponse *beginResponse(FS &fs, const String& path, const String& contentType=String(), bool download=false, AwsTemplateProcessor callback=nullptr);
+    AsyncWebServerResponse *beginResponse(File content, const String& path, const String& contentType=String(), bool download=false, AwsTemplateProcessor callback=nullptr);
     AsyncWebServerResponse *beginResponse(Stream &stream, const String& contentType, size_t len);
     AsyncWebServerResponse *beginResponse(const String& contentType, size_t len, AwsResponseFiller callback);
     AsyncWebServerResponse *beginChunkedResponse(const String& contentType, AwsResponseFiller callback);

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -39,6 +39,7 @@ class AsyncStaticWebHandler: public AsyncWebHandler {
     String _default_file;
     String _cache_control;
     String _last_modified;
+    AwsTemplateProcessor _callback;
     bool _isDir;
     bool _gzipFirst;
     uint8_t _gzipStats;
@@ -55,6 +56,7 @@ class AsyncStaticWebHandler: public AsyncWebHandler {
     AsyncStaticWebHandler& setLastModified(time_t last_modified);
     AsyncStaticWebHandler& setLastModified(); //sets to current time. Make sure sntp is runing and time is updated
   #endif
+    AsyncStaticWebHandler& setTemplateProcessor(AwsTemplateProcessor newCallback) {_callback = newCallback; return *this;}
 };
 
 class AsyncCallbackWebHandler: public AsyncWebHandler {

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -22,7 +22,7 @@
 #include "WebHandlerImpl.h"
 
 AsyncStaticWebHandler::AsyncStaticWebHandler(const char* uri, FS& fs, const char* path, const char* cache_control)
-  : _fs(fs), _uri(uri), _path(path), _default_file("index.htm"), _cache_control(cache_control), _last_modified("")
+  : _fs(fs), _uri(uri), _path(path), _default_file("index.htm"), _cache_control(cache_control), _last_modified(""), _callback(nullptr)
 {
   // Ensure leading '/'
   if (_uri.length() == 0 || _uri[0] != '/') _uri = "/" + _uri;
@@ -196,7 +196,7 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request)
       response->addHeader("ETag", etag);
       request->send(response);
     } else {
-      AsyncWebServerResponse * response = new AsyncFileResponse(request->_tempFile, filename);
+      AsyncWebServerResponse * response = new AsyncFileResponse(request->_tempFile, filename, String(), false, _callback);
       if (_last_modified.length())
         response->addHeader("Last-Modified", _last_modified);
       if (_cache_control.length()){

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -673,15 +673,15 @@ AsyncWebServerResponse * AsyncWebServerRequest::beginResponse(int code, const St
   return new AsyncBasicResponse(code, contentType, content);
 }
 
-AsyncWebServerResponse * AsyncWebServerRequest::beginResponse(FS &fs, const String& path, const String& contentType, bool download){
+AsyncWebServerResponse * AsyncWebServerRequest::beginResponse(FS &fs, const String& path, const String& contentType, bool download, AwsTemplateProcessor callback){
   if(fs.exists(path) || (!download && fs.exists(path+".gz")))
-    return new AsyncFileResponse(fs, path, contentType, download);
+    return new AsyncFileResponse(fs, path, contentType, download, callback);
   return NULL;
 }
 
-AsyncWebServerResponse * AsyncWebServerRequest::beginResponse(File content, const String& path, const String& contentType, bool download){
+AsyncWebServerResponse * AsyncWebServerRequest::beginResponse(File content, const String& path, const String& contentType, bool download, AwsTemplateProcessor callback){
   if(content == true)
-    return new AsyncFileResponse(content, path, contentType, download);
+    return new AsyncFileResponse(content, path, contentType, download, callback);
   return NULL;
 }
 
@@ -715,15 +715,15 @@ void AsyncWebServerRequest::send(int code, const String& contentType, const Stri
   send(beginResponse(code, contentType, content));
 }
 
-void AsyncWebServerRequest::send(FS &fs, const String& path, const String& contentType, bool download){
+void AsyncWebServerRequest::send(FS &fs, const String& path, const String& contentType, bool download, AwsTemplateProcessor callback){
   if(fs.exists(path) || (!download && fs.exists(path+".gz"))){
-    send(beginResponse(fs, path, contentType, download));
+    send(beginResponse(fs, path, contentType, download, callback));
   } else send(404);
 }
 
-void AsyncWebServerRequest::send(File content, const String& path, const String& contentType, bool download){
+void AsyncWebServerRequest::send(File content, const String& path, const String& contentType, bool download, AwsTemplateProcessor callback){
   if(content == true){
-    send(beginResponse(content, path, contentType, download));
+    send(beginResponse(content, path, contentType, download, callback));
   } else send(404);
 }
 

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -22,6 +22,17 @@
 #include "WebResponseImpl.h"
 #include "cbuf.h"
 
+// Since ESP8266 does not link memchr by default, here's its implementation.
+void* memchr(void* ptr, int ch, size_t count)
+{
+  unsigned char* p = static_cast<unsigned char*>(ptr);
+  while(count--)
+    if(*p++ == static_cast<unsigned char>(ch))
+      return --p;
+  return nullptr;
+}
+
+
 /*
  * Abstract Response
  * */
@@ -176,7 +187,7 @@ void AsyncBasicResponse::_respond(AsyncWebServerRequest *request){
     outLen += _contentLength;
     _writtenLength += request->client()->write(out.c_str(), outLen);
     _state = RESPONSE_WAIT_ACK;
-  } else if(space && space < out.length()){
+  } else if(space && space < outLen){
     String partial = out.substring(0, space);
     _content = out.substring(space) + _content;
     _contentLength += outLen - space;
@@ -284,14 +295,14 @@ size_t AsyncAbstractResponse::_ack(AsyncWebServerRequest *request, size_t len, u
     size_t readLen = 0;
 
     if(_chunked){
-      readLen = _fillBuffer(buf+headLen, outLen - 8);
-      char pre[6];
-      sprintf(pre, "%x\r\n", readLen);
-      size_t preLen = strlen(pre);
-      memmove(buf+headLen+preLen, buf+headLen, readLen);
-      for(size_t i=0; i<preLen; i++)
-        buf[i+headLen] = pre[i];
-      outLen = preLen + readLen + headLen;
+      // HTTP 1.1 allows leading/trailing zeros in chunk length. Or spaces may be added.
+      // See RFC2616 sections 2, 3.6.1.
+      readLen = _fillBuffer(buf+headLen+6, outLen - 8);
+      outLen = sprintf((char*)buf+headLen, "%x", readLen) + headLen;
+      while(outLen < headLen + 4) buf[outLen++] = ' ';
+      buf[outLen++] = '\r';
+      buf[outLen++] = '\n';
+      outLen += readLen;
       buf[outLen++] = '\r';
       buf[outLen++] = '\n';
     } else {
@@ -357,17 +368,26 @@ void AsyncFileResponse::_setContentType(const String& path){
   else _contentType = "text/plain";
 }
 
-AsyncFileResponse::AsyncFileResponse(FS &fs, const String& path, const String& contentType, bool download){
+AsyncFileResponse::AsyncFileResponse(FS &fs, const String& path, const String& contentType, bool download, AwsTemplateProcessor callback){
   _code = 200;
   _path = path;
 
   if(!download && !fs.exists(_path) && fs.exists(_path+".gz")){
     _path = _path+".gz";
     addHeader("Content-Encoding", "gzip");
+    callback = nullptr; // Unable to process zipped templates
   }
 
   _content = fs.open(_path, "r");
   _contentLength = _content.size();
+
+  // In case of template processing, we're unable to determine real response size
+  if(callback) {
+    _contentLength = 0;
+    _sendContentLength = false;
+    _chunked = true;
+  }
+  _callback = callback;
 
   if(contentType == "")
     _setContentType(path);
@@ -386,17 +406,26 @@ AsyncFileResponse::AsyncFileResponse(FS &fs, const String& path, const String& c
     snprintf(buf, sizeof (buf), "inline; filename=\"%s\"", filename);
   }
   addHeader("Content-Disposition", buf);
-
 }
 
-AsyncFileResponse::AsyncFileResponse(File content, const String& path, const String& contentType, bool download){
+AsyncFileResponse::AsyncFileResponse(File content, const String& path, const String& contentType, bool download, AwsTemplateProcessor callback){
   _code = 200;
   _path = path;
   _content = content;
   _contentLength = _content.size();
 
-  if(!download && String(_content.name()).endsWith(".gz") && !path.endsWith(".gz"))
+  if(!download && String(_content.name()).endsWith(".gz") && !path.endsWith(".gz")){
     addHeader("Content-Encoding", "gzip");
+    callback = nullptr; // Unable to process gzipped templates
+  }
+
+  // In case of template processing, we're unable to determine real response size
+  if(callback) {
+    _contentLength = 0;
+    _sendContentLength = false;
+    _chunked = true;
+  }
+  _callback = callback;
 
   if(contentType == "")
     _setContentType(path);
@@ -415,8 +444,118 @@ AsyncFileResponse::AsyncFileResponse(File content, const String& path, const Str
   addHeader("Content-Disposition", buf);
 }
 
+size_t AsyncFileResponse::_readDataFromCacheOrFile(uint8_t* data, const size_t len)
+{
+    // If we have something in cache, copy it to buffer
+    const size_t readFromCache = std::min(len, _cache.size());
+    if(readFromCache) {
+      memcpy(data, _cache.data(), readFromCache);
+      _cache.erase(_cache.begin(), _cache.begin() + readFromCache);
+    }
+    // If we need to read more...
+    const size_t needFromFile = len - readFromCache;
+    const size_t readFromFile = _content.read(data + readFromCache, needFromFile);
+    return readFromCache + readFromFile;
+}
+
 size_t AsyncFileResponse::_fillBuffer(uint8_t *data, size_t len){
-  _content.read(data, len);
+  // Retain old behaviour without callback
+  if(!_callback) {
+    _content.read(data, len);
+    return len;
+  }
+
+  const size_t originalLen = len;
+  len = _readDataFromCacheOrFile(data, len);
+  // Now we've read 'len' bytes, either from cache or from file
+  // Search for template placeholders
+  uint8_t* pTemplateStart = data;
+  while((pTemplateStart < &data[len]) && (pTemplateStart = (uint8_t*)memchr(pTemplateStart, TEMPLATE_PLACEHOLDER, &data[len - 1] - pTemplateStart + 1))) { // data[0] ... data[len - 1]
+    uint8_t* pTemplateEnd = (pTemplateStart < &data[len - 1]) ? (uint8_t*)memchr(pTemplateStart + 1, TEMPLATE_PLACEHOLDER, &data[len - 1] - pTemplateStart) : nullptr;
+    // temporary buffer to hold parameter name
+    uint8_t buf[TEMPLATE_PARAM_NAME_LENGTH + 1];
+    String paramName;
+    // cache position to insert remainder of template parameter value
+    std::vector<uint8_t>::iterator i = _cache.end();
+    // If closing placeholder is found:
+    if(pTemplateEnd) {
+      // prepare argument to callback
+      const size_t paramNameLength = std::min(sizeof(buf) - 1, (unsigned int)(pTemplateEnd - pTemplateStart - 1));
+      if(paramNameLength) {
+        memcpy(buf, pTemplateStart + 1, paramNameLength);
+        buf[paramNameLength] = 0;
+        paramName = String(reinterpret_cast<char*>(buf));
+      } else { // double percent sign encountered, this is single percent sign escaped.
+        // remove the 2nd percent sign
+        memmove(pTemplateEnd, pTemplateEnd + 1, &data[len] - pTemplateEnd - 1);
+        len += _readDataFromCacheOrFile(&data[len - 1], 1) - 1;
+        ++pTemplateStart;
+      }
+    } else if(&data[len - 1] - pTemplateStart + 1 < TEMPLATE_PARAM_NAME_LENGTH + 2) { // closing placeholder not found, check if it's in the remaining file data
+      if(_cache.size() || (_content.position() < _content.size())) {
+        memcpy(buf, pTemplateStart + 1, &data[len - 1] - pTemplateStart);
+        const size_t readFromCacheOrFile = _readDataFromCacheOrFile(buf + (&data[len - 1] - pTemplateStart), TEMPLATE_PARAM_NAME_LENGTH + 2 - (&data[len - 1] - pTemplateStart + 1));
+        pTemplateEnd = (uint8_t*)memchr(buf + (&data[len - 1] - pTemplateStart), TEMPLATE_PLACEHOLDER, readFromCacheOrFile);
+        if(pTemplateEnd) {
+          // prepare argument to callback
+          *pTemplateEnd = 0;
+          paramName = String(reinterpret_cast<char*>(buf));
+          // Copy remaining read-ahead data into cache (when std::vector::insert returning iterator will be available, these 3 lines can be simplified into 1)
+          const size_t pos = _cache.size();
+          _cache.insert(_cache.end(), pTemplateEnd + 1, buf + (&data[len - 1] - pTemplateStart) + readFromCacheOrFile);
+          i = _cache.begin() + pos;
+          pTemplateEnd = &data[len - 1];
+        }
+        else // closing placeholder not found in file data, store found percent symbol as is and advance to the next position
+        {
+          // but first, store read file data in cache
+          _cache.insert(_cache.end(), buf + (&data[len - 1] - pTemplateStart), buf + (&data[len - 1] - pTemplateStart) + readFromCacheOrFile);
+          ++pTemplateStart;
+        }
+      }
+      else // closing placeholder not found in file data, store found percent symbol as is and advance to the next position
+        ++pTemplateStart;
+    }
+    else // closing placeholder not found in file data, store found percent symbol as is and advance to the next position
+      ++pTemplateStart;
+    if(paramName.length()) {
+      // call callback and replace with result.
+      // Everything in range [pTemplateStart, pTemplateEnd] can be safely replaced with parameter value.
+      // Data after pTemplateEnd may need to be moved.
+      // The first byte of data after placeholder is located at pTemplateEnd + 1.
+      // It should be located at pTemplateStart + numBytesCopied (to begin right after inserted parameter value).
+      const String paramValue(_callback(paramName));
+      const char* pvstr = paramValue.c_str();
+      const unsigned int pvlen = paramValue.length();
+      const size_t numBytesCopied = std::min(pvlen, static_cast<unsigned int>(&data[originalLen - 1] - pTemplateStart + 1));
+      // make room for param value
+      // 1. move extra data to cache if parameter value is longer than placeholder AND if there is no room to store
+      if((pTemplateEnd + 1 < pTemplateStart + numBytesCopied) && (originalLen - (pTemplateStart + numBytesCopied - pTemplateEnd - 1) < len)) {
+        size_t pos = i - _cache.begin();
+        _cache.insert(i, &data[originalLen - (pTemplateStart + numBytesCopied - pTemplateEnd - 1)], &data[len]);
+        i = _cache.begin() + pos;
+        //2. parameter value is longer than placeholder text, push the data after placeholder which not saved into cache further to the end
+        memmove(pTemplateStart + numBytesCopied, pTemplateEnd + 1, &data[originalLen] - pTemplateStart - numBytesCopied);
+      } else if(pTemplateEnd + 1 != pTemplateStart + numBytesCopied)
+        //2. Either parameter value is shorter than placeholder text OR there is enough free space in buffer to fit.
+        //   Move the entire data after the placeholder
+        memmove(pTemplateStart + numBytesCopied, pTemplateEnd + 1, &data[len] - pTemplateEnd - 1);
+      // 3. replace placeholder with actual value
+      memcpy(pTemplateStart, pvstr, numBytesCopied);
+      // If result is longer than buffer, copy the remainder into cache (this could happen only if placeholder text itself did not fit entirely in buffer)
+      if(numBytesCopied < pvlen) {
+        _cache.insert(i, pvstr + numBytesCopied, pvstr + pvlen);
+      } else if(pTemplateStart + numBytesCopied < pTemplateEnd + 1) { // result is copied fully; if result is shorter than placeholder text...
+        // there is some free room, fill it from cache
+        const size_t roomFreed = pTemplateEnd + 1 - pTemplateStart - numBytesCopied;
+        const size_t totalFreeRoom = originalLen - len + roomFreed;
+        len += _readDataFromCacheOrFile(&data[len - roomFreed], totalFreeRoom) - roomFreed;
+      } else { // result is copied fully; it is longer than placeholder text
+        const size_t roomTaken = pTemplateStart + numBytesCopied - pTemplateEnd - 1;
+        len = std::min(len + roomTaken, originalLen);
+      }
+    }
+  } // while(pTemplateStart)
   return len;
 }
 


### PR DESCRIPTION
Unzipped files may have template placeholders like `%TEMPLATE_VAR%` inside. If callback is specified in `AsyncFileResponse` constructor call, it will be used to replace these with actual strings.
The prototype of callback is `String(const String&)`, i.e. it gets variable name and returns its value.
Template variables' delimiter is currently percent sign (`%`).
Maximal placeholder length is 32 chars (chosen somewhat arbitrarily, it may be stored on stack during processing). It is not guaranteed that placeholders longer than that will be processed.

Signed-off-by: Alexandr Zarubkin <me21@yandex.ru>