### PR TITLE
Add basic ESP32 support

### DIFF
--- a/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
+++ b/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
@@ -98,7 +98,7 @@ void setup(){
   WiFi.mode(WIFI_AP_STA);
   WiFi.softAP(hostName);
   WiFi.begin(ssid, password);
-  if (WiFi.waitForConnectResult() != WL_CONNECTED) {
+  while (WiFi.waitForConnectResult() != WL_CONNECTED) {
     Serial.printf("STA: Failed!\n");
     WiFi.disconnect(false);
     delay(1000);

--- a/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
+++ b/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
@@ -139,6 +139,10 @@ void setup(){
 
   server.addHandler(new SPIFFSEditor(http_username,http_password));
 
+  server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
+    request->redirect("/edit");
+  });
+
   server.on("/heap", HTTP_GET, [](AsyncWebServerRequest *request){
     request->send(200, "text/plain", String(ESP.getFreeHeap()));
   });

--- a/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
+++ b/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
@@ -104,6 +104,8 @@ void setup(){
     delay(1000);
     WiFi.begin(ssid, password);
   }
+  Serial.printf("WiFi Connected!\n");
+  Serial.println(WiFi.localIP());
 
   //Send OTA events to the browser
   ArduinoOTA.onStart([]() { events.send("Update Start", "ota"); });

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -168,7 +168,11 @@ class AsyncWebSocketClient {
     void message(AsyncWebSocketMessage *message){ _queueMessage(message); }
 
     size_t printf(const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
+#if ESP8266
     size_t printf_P(PGM_P formatP, ...)  __attribute__ ((format (printf, 2, 3)));
+#elif ESP32
+    size_t printf_PGM(PGM_P formatP, ...)  __attribute__ ((format (printf, 2, 3)));
+#endif
 
     void text(const char * message, size_t len);
     void text(const char * message);
@@ -257,7 +261,11 @@ class AsyncWebSocket: public AsyncWebHandler {
 
     size_t printf(uint32_t id, const char *format, ...)  __attribute__ ((format (printf, 3, 4)));
     size_t printfAll(const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
+#if ESP8266
     size_t printf_P(uint32_t id, PGM_P formatP, ...)  __attribute__ ((format (printf, 3, 4)));
+#elif ESP32
+    size_t printf_PGM(uint32_t id, PGM_P formatP, ...)  __attribute__ ((format (printf, 3, 4)));
+#endif
     size_t printfAll_P(PGM_P formatP, ...)  __attribute__ ((format (printf, 2, 3)));
 
     //event listener

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -29,10 +29,21 @@
 
 #include "StringArray.h"
 
-#if defined(ESP31B)
-#include <ESP31BWiFi.h>
-#elif defined(ESP8266)
+#if defined(ESP8266)
 #include <ESP8266WiFi.h>
+#elif defined(ESP31B)
+#include <ESP31BWiFi.h>
+#elif defined(ESP32)
+#include <WiFi.h>
+
+// Uncomment to mark that support for ESP32 SPIFFS is available.
+// The library can be downloaded from https://github.com/copercini/arduino-esp32-SPIFFS
+//#define HAS_ARDUINO_ESP32_SPIFFS
+
+#ifdef HAS_ARDUINO_ESP32_SPIFFS
+#include <SPIFFS.h>
+#endif
+
 #else
 #error Platform not supported
 #endif

--- a/src/SPIFFSEditor.h
+++ b/src/SPIFFSEditor.h
@@ -2,6 +2,8 @@
 #define SPIFFSEditor_H_
 #include <ESPAsyncWebServer.h>
 
+#if defined(ESP8266) || defined(HAS_ARDUINO_ESP32_SPIFFS)
+
 #define EXCLUDELIST "/.exclude.files"
 
 class SPIFFSEditor: public AsyncWebHandler {
@@ -17,5 +19,7 @@ class SPIFFSEditor: public AsyncWebHandler {
     virtual void handleUpload(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final) override final;
 
 };
+
+#endif
 
 #endif

--- a/src/WebAuthentication.cpp
+++ b/src/WebAuthentication.cpp
@@ -20,7 +20,12 @@
 */
 #include "WebAuthentication.h"
 #include <libb64/cencode.h>
+
+#ifdef ESP8266
 #include "md5.h"
+#elif ESP32
+#include "mbedtls/md5.h"
+#endif
 
 // Basic Auth hash = base64("username:password")
 
@@ -54,15 +59,19 @@ bool checkBasicAuthentication(const char * hash, const char * username, const ch
 }
 
 static bool getMD5(uint8_t * data, uint16_t len, char * output){//33 bytes or more
-  md5_context_t _ctx;
   uint8_t i;
   uint8_t * _buf = (uint8_t*)malloc(16);
   if(_buf == NULL)
     return false;
   memset(_buf, 0x00, 16);
+#ifdef ESP8266
+  md5_context_t _ctx;
   MD5Init(&_ctx);
   MD5Update(&_ctx, data, len);
   MD5Final(_buf, &_ctx);
+#elif ESP32
+  mbedtls_md5(data, len, _buf);
+#endif
   for(i = 0; i < 16; i++) {
     sprintf(output + (i * 2), "%02x", _buf[i]);
   }

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -26,6 +26,10 @@
 #define os_strlen strlen
 #endif
 
+#ifdef ESP32
+#define os_printf ets_printf
+#endif
+
 static const String SharedEmptyString = String();
 
 #define __is_param_char(c) ((c) && ((c) != '{') && ((c) != '[') && ((c) != '&') && ((c) != '='))


### PR DESCRIPTION
Hi, I've patched up the code to get it running with the current Arduino-ESP32. It works both on ESP8266 and ESP32. It actually forces code paths only for ESP8266 or ESP32, is ESP31B any relevant?

You need patched ESPAsyncTCP to run this - https://github.com/vincasmiliunas/ESPAsyncTCP

At this time Arduino-ESP32 does provide any SPIFFS library [1], thus you need to download one from third party [2]. HAS_ARDUINO_ESP32_SPIFFS is used mark that it's available.
[1] - https://github.com/espressif/arduino-esp32/tree/master/libraries
[2] - https://github.com/copercini/arduino-esp32-SPIFFS

This patch uses new APIs or applies workarounds to fix the incompatibilies between ESP8266 and ESP32, like Arduino-ESP32 [1] destroying method names with C preprocesor macros, unlike Arduino-ESP8266 [2].
[1] - https://github.com/espressif/arduino-esp32/blob/master/cores/esp32/pgmspace.h#L65
[2] - https://github.com/esp8266/Arduino/blob/master/cores/esp8266/pgmspace.h#L77
