### PR TITLE
Address compilation warning.

### DIFF
--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -97,7 +97,7 @@ AsyncWebServerRequest::~AsyncWebServerRequest(){
 }
 
 void AsyncWebServerRequest::_onData(void *buf, size_t len){
-  int i = 0;
+  size_t i = 0;
   while (true) {
 
   if(_parseState < PARSE_REQ_BODY){


### PR DESCRIPTION
Specifically: "warning: comparison between signed and unsigned integer
expressions".  Make `i` the same type as `len`, which it is frequently
compared to.