### PR TITLE
rename HTTP_* to avoid redeclaration errors with ESP8266WebServer.h

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ To use this library you might need to have the latest git versions of [ESP8266](
 ### Common Variables
 ```cpp
 request->version();       // uint8_t: 0 = HTTP/1.0, 1 = HTTP/1.1
-request->method();        // enum:    HTTP_GET, HTTP_POST, HTTP_DELETE, HTTP_PUT, HTTP_PATCH, HTTP_HEAD, HTTP_OPTIONS
+request->method();        // enum:    ASYNC_HTTP_GET, ASYNC_HTTP_POST, ASYNC_HTTP_DELETE, ASYNC_HTTP_PUT, ASYNC_HTTP_PATCH, ASYNC_HTTP_HEAD, ASYNC_HTTP_OPTIONS
 request->url();           // String:  URL of the request (not including host, port or GET parameters)
 request->host();          // String:  The requested host (can be used for virtual hosting)
 request->contentType();   // String:  ContentType of the request (not avaiable in Handler::canHandle)
@@ -1071,7 +1071,7 @@ if (!!window.EventSource) {
 ```cpp
 //First request will return 0 results unless you start scan from somewhere else (loop/setup)
 //Do not request more often than 3-5 seconds
-server.on("/scan", HTTP_GET, [](AsyncWebServerRequest *request){
+server.on("/scan", ASYNC_HTTP_GET, [](AsyncWebServerRequest *request){
   String json = "[";
   int n = WiFi.scanComplete();
   if(n == -2){
@@ -1176,32 +1176,32 @@ void setup(){
   server.addHandler(&events);
 
   // respond to GET requests on URL /heap
-  server.on("/heap", HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on("/heap", ASYNC_HTTP_GET, [](AsyncWebServerRequest *request){
     request->send(200, "text/plain", String(ESP.getFreeHeap()));
   });
 
   // upload a file to /upload
-  server.on("/upload", HTTP_POST, [](AsyncWebServerRequest *request){
+  server.on("/upload", ASYNC_HTTP_POST, [](AsyncWebServerRequest *request){
     request->send(200);
   }, onUpload);
 
   // send a file when /index is requested
-  server.on("/index", HTTP_ANY, [](AsyncWebServerRequest *request){
+  server.on("/index", ASYNC_HTTP_ANY, [](AsyncWebServerRequest *request){
     request->send(SPIFFS, "/index.htm");
   });
 
   // HTTP basic authentication
-  server.on("/login", HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on("/login", ASYNC_HTTP_GET, [](AsyncWebServerRequest *request){
     if(!request->authenticate(http_username, http_password))
         return request->requestAuthentication();
     request->send(200, "text/plain", "Login Success!");
   });
 
   // Simple Firmware Update Form
-  server.on("/update", HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on("/update", ASYNC_HTTP_GET, [](AsyncWebServerRequest *request){
     request->send(200, "text/html", "<form method='POST' action='/update' enctype='multipart/form-data'><input type='file' name='update'><input type='submit' value='Update'></form>");
   });
-  server.on("/update", HTTP_POST, [](AsyncWebServerRequest *request){
+  server.on("/update", ASYNC_HTTP_POST, [](AsyncWebServerRequest *request){
     shouldReboot = !Update.hasError();
     AsyncWebServerResponse *response = request->beginResponse(200, "text/plain", shouldReboot?"OK":"FAIL");
     response->addHeader("Connection", "close");
@@ -1280,10 +1280,10 @@ public :
 	void begin(){
 
 		// attach global request handler
-		classWebServer.on("/example", HTTP_ANY, handleRequest);
+		classWebServer.on("/example", ASYNC_HTTP_ANY, handleRequest);
 
 		// attach class request handler
-		classWebServer.on("/example", HTTP_ANY, std::bind(&WebClass::classRequest, this, std::placeholders::_1));
+		classWebServer.on("/example", ASYNC_HTTP_ANY, std::bind(&WebClass::classRequest, this, std::placeholders::_1));
 	}
 };
 
@@ -1293,10 +1293,10 @@ WebClass webClassInstance;
 void setup() {
 
 	// attach global request handler
-	globalWebServer.on("/example", HTTP_ANY, handleRequest);
+	globalWebServer.on("/example", ASYNC_HTTP_ANY, handleRequest);
 
 	// attach class request handler
-	globalWebServer.on("/example", HTTP_ANY, std::bind(&WebClass::classRequest, webClassInstance, std::placeholders::_1));
+	globalWebServer.on("/example", ASYNC_HTTP_ANY, std::bind(&WebClass::classRequest, webClassInstance, std::placeholders::_1));
 }
 
 void loop() {

--- a/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
+++ b/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
@@ -137,7 +137,7 @@ void setup(){
 
   server.addHandler(new SPIFFSEditor(http_username,http_password));
 
-  server.on("/heap", HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on("/heap", ASYNC_HTTP_GET, [](AsyncWebServerRequest *request){
     request->send(200, "text/plain", String(ESP.getFreeHeap()));
   });
 
@@ -145,19 +145,19 @@ void setup(){
 
   server.onNotFound([](AsyncWebServerRequest *request){
     Serial.printf("NOT_FOUND: ");
-    if(request->method() == HTTP_GET)
+    if(request->method() == ASYNC_HTTP_GET)
       Serial.printf("GET");
-    else if(request->method() == HTTP_POST)
+    else if(request->method() == ASYNC_HTTP_POST)
       Serial.printf("POST");
-    else if(request->method() == HTTP_DELETE)
+    else if(request->method() == ASYNC_HTTP_DELETE)
       Serial.printf("DELETE");
-    else if(request->method() == HTTP_PUT)
+    else if(request->method() == ASYNC_HTTP_PUT)
       Serial.printf("PUT");
-    else if(request->method() == HTTP_PATCH)
+    else if(request->method() == ASYNC_HTTP_PATCH)
       Serial.printf("PATCH");
-    else if(request->method() == HTTP_HEAD)
+    else if(request->method() == ASYNC_HTTP_HEAD)
       Serial.printf("HEAD");
-    else if(request->method() == HTTP_OPTIONS)
+    else if(request->method() == ASYNC_HTTP_OPTIONS)
       Serial.printf("OPTIONS");
     else
       Serial.printf("UNKNOWN");

--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -307,7 +307,7 @@ size_t AsyncEventSource::count() const {
 }
 
 bool AsyncEventSource::canHandle(AsyncWebServerRequest *request){
-  if(request->method() != HTTP_GET || !request->url().equals(_url) || !request->isExpectedRequestedConnType(RCT_EVENT))
+  if(request->method() != ASYNC_HTTP_GET || !request->url().equals(_url) || !request->isExpectedRequestedConnType(RCT_EVENT))
     return false;
   request->addInterestingHeader("Last-Event-ID");
   return true;

--- a/src/AsyncJson.h
+++ b/src/AsyncJson.h
@@ -5,7 +5,7 @@
 
   example of callback in use
 
-   server.on("/json", HTTP_ANY, [](AsyncWebServerRequest * request) {
+   server.on("/json", ASYNC_HTTP_ANY, [](AsyncWebServerRequest * request) {
 
     AsyncJsonResponse * response = new AsyncJsonResponse();
     JsonObject& root = response->getRoot();

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1075,7 +1075,7 @@ bool AsyncWebSocket::canHandle(AsyncWebServerRequest *request){
   if(!_enabled)
     return false;
   
-  if(request->method() != HTTP_GET || !request->url().equals(_url) || !request->isExpectedRequestedConnType(RCT_WS))
+  if(request->method() != ASYNC_HTTP_GET || !request->url().equals(_url) || !request->isExpectedRequestedConnType(RCT_WS))
     return false;
 
   request->addInterestingHeader(WS_STR_CONNECTION);

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -52,14 +52,14 @@ class AsyncCallbackWebHandler;
 class AsyncResponseStream;
 
 typedef enum {
-  HTTP_GET     = 0b00000001,
-  HTTP_POST    = 0b00000010,
-  HTTP_DELETE  = 0b00000100,
-  HTTP_PUT     = 0b00001000,
-  HTTP_PATCH   = 0b00010000,
-  HTTP_HEAD    = 0b00100000,
-  HTTP_OPTIONS = 0b01000000,
-  HTTP_ANY     = 0b01111111,
+  ASYNC_HTTP_GET     = 0b00000001,
+  ASYNC_HTTP_POST    = 0b00000010,
+  ASYNC_HTTP_DELETE  = 0b00000100,
+  ASYNC_HTTP_PUT     = 0b00001000,
+  ASYNC_HTTP_PATCH   = 0b00010000,
+  ASYNC_HTTP_HEAD    = 0b00100000,
+  ASYNC_HTTP_OPTIONS = 0b01000000,
+  ASYNC_HTTP_ANY     = 0b01111111,
 } WebRequestMethod;
 typedef uint8_t WebRequestMethodComposite;
 
@@ -248,19 +248,19 @@ class AsyncWebServerRequest {
     bool hasParam(const __FlashStringHelper * data, bool post=false, bool file=false) const;
 
     AsyncWebParameter* getParam(const String& name, bool post=false, bool file=false) const;
-    AsyncWebParameter* getParam(const __FlashStringHelper * data, bool post, bool file) const; 
+    AsyncWebParameter* getParam(const __FlashStringHelper * data, bool post, bool file) const;
     AsyncWebParameter* getParam(size_t num) const;
 
     size_t args() const { return params(); }     // get arguments count
     const String& arg(const String& name) const; // get request argument value by name
-    const String& arg(const __FlashStringHelper * data) const; // get request argument value by F(name)    
+    const String& arg(const __FlashStringHelper * data) const; // get request argument value by F(name)
     const String& arg(size_t i) const;           // get request argument value by number
     const String& argName(size_t i) const;       // get request argument name by number
     bool hasArg(const char* name) const;         // check if argument exists
     bool hasArg(const __FlashStringHelper * data) const;         // check if F(argument) exists
 
     const String& header(const char* name) const;// get request header value by name
-    const String& header(const __FlashStringHelper * data) const;// get request header value by F(name)    
+    const String& header(const __FlashStringHelper * data) const;// get request header value by F(name)
     const String& header(size_t i) const;        // get request header value by number
     const String& headerName(size_t i) const;    // get request header name by number
     String urlDecode(const String& text) const;
@@ -395,7 +395,7 @@ class AsyncWebServer {
 
     AsyncWebHandler& addHandler(AsyncWebHandler* handler);
     bool removeHandler(AsyncWebHandler* handler);
-  
+
     AsyncCallbackWebHandler& on(const char* uri, ArRequestHandlerFunction onRequest);
     AsyncCallbackWebHandler& on(const char* uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest);
     AsyncCallbackWebHandler& on(const char* uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload);
@@ -407,8 +407,8 @@ class AsyncWebServer {
     void onFileUpload(ArUploadHandlerFunction fn); //handle file uploads
     void onRequestBody(ArBodyHandlerFunction fn); //handle posts with plain body content (JSON often transmitted this way as a request)
 
-    void reset(); //remove all writers and handlers, with onNotFound/onFileUpload/onRequestBody 
-  
+    void reset(); //remove all writers and handlers, with onNotFound/onFileUpload/onRequestBody
+
     void _handleDisconnect(AsyncWebServerRequest *request);
     void _attachHandler(AsyncWebServerRequest *request);
     void _rewriteRequest(AsyncWebServerRequest *request);

--- a/src/SPIFFSEditor.cpp
+++ b/src/SPIFFSEditor.cpp
@@ -341,7 +341,7 @@ SPIFFSEditor::SPIFFSEditor(const String& username, const String& password)
 
 bool SPIFFSEditor::canHandle(AsyncWebServerRequest *request){
   if(request->url().equalsIgnoreCase("/edit")){
-    if(request->method() == HTTP_GET){
+    if(request->method() == ASYNC_HTTP_GET){
       if(request->hasParam("list"))
         return true;
       if(request->hasParam("edit")){
@@ -356,11 +356,11 @@ bool SPIFFSEditor::canHandle(AsyncWebServerRequest *request){
       }
       return true;
     }
-    else if(request->method() == HTTP_POST)
+    else if(request->method() == ASYNC_HTTP_POST)
       return true;
-    else if(request->method() == HTTP_DELETE)
+    else if(request->method() == ASYNC_HTTP_DELETE)
       return true;
-    else if(request->method() == HTTP_PUT)
+    else if(request->method() == ASYNC_HTTP_PUT)
       return true;
 
   }
@@ -372,7 +372,7 @@ void SPIFFSEditor::handleRequest(AsyncWebServerRequest *request){
   if(_username.length() && _password.length() && !request->authenticate(_username.c_str(), _password.c_str()))
     return request->requestAuthentication();
 
-  if(request->method() == HTTP_GET){
+  if(request->method() == ASYNC_HTTP_GET){
     if(request->hasParam("list")){
       String path = request->getParam("list")->value();
       Dir dir = SPIFFS.openDir(path);
@@ -403,18 +403,18 @@ void SPIFFSEditor::handleRequest(AsyncWebServerRequest *request){
       response->addHeader("Content-Encoding", "gzip");
       request->send(response);
     }
-  } else if(request->method() == HTTP_DELETE){
+  } else if(request->method() == ASYNC_HTTP_DELETE){
     if(request->hasParam("path", true)){
       SPIFFS.remove(request->getParam("path", true)->value());
       request->send(200, "", "DELETE: "+request->getParam("path", true)->value());
     } else
       request->send(404);
-  } else if(request->method() == HTTP_POST){
+  } else if(request->method() == ASYNC_HTTP_POST){
     if(request->hasParam("data", true, true) && SPIFFS.exists(request->getParam("data", true, true)->value()))
       request->send(200, "", "UPLOADED: "+request->getParam("data", true, true)->value());
     else
       request->send(500);
-  } else if(request->method() == HTTP_PUT){
+  } else if(request->method() == ASYNC_HTTP_PUT){
     if(request->hasParam("path", true)){
       String filename = request->getParam("path", true)->value();
       if(SPIFFS.exists(filename)){

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -68,7 +68,7 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
     ArUploadHandlerFunction _onUpload;
     ArBodyHandlerFunction _onBody;
   public:
-    AsyncCallbackWebHandler() : _uri(), _method(HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL){}
+    AsyncCallbackWebHandler() : _uri(), _method(ASYNC_HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL){}
     void setUri(const String& uri){ _uri = uri; }
     void setMethod(WebRequestMethodComposite method){ _method = method; }
     void onRequest(ArRequestHandlerFunction fn){ _onRequest = fn; }

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -81,7 +81,7 @@ AsyncStaticWebHandler& AsyncStaticWebHandler::setLastModified(){
 }
 #endif
 bool AsyncStaticWebHandler::canHandle(AsyncWebServerRequest *request){
-  if(request->method() != HTTP_GET 
+  if(request->method() != ASYNC_HTTP_GET 
     || !request->url().startsWith(_uri) 
     || !request->isExpectedRequestedConnType(RCT_DEFAULT, RCT_HTTP)
   ){

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -40,7 +40,7 @@ AsyncWebServerRequest::AsyncWebServerRequest(AsyncWebServer* s, AsyncClient* c)
   , _temp()
   , _parseState(0)
   , _version(0)
-  , _method(HTTP_ANY)
+  , _method(ASYNC_HTTP_ANY)
   , _url()
   , _host()
   , _contentType()
@@ -238,19 +238,19 @@ bool AsyncWebServerRequest::_parseReqHead(){
   _temp = _temp.substring(index+1);
 
   if(m == "GET"){
-    _method = HTTP_GET;
+    _method = ASYNC_HTTP_GET;
   } else if(m == "POST"){
-    _method = HTTP_POST;
+    _method = ASYNC_HTTP_POST;
   } else if(m == "DELETE"){
-    _method = HTTP_DELETE;
+    _method = ASYNC_HTTP_DELETE;
   } else if(m == "PUT"){
-    _method = HTTP_PUT;
+    _method = ASYNC_HTTP_PUT;
   } else if(m == "PATCH"){
-    _method = HTTP_PATCH;
+    _method = ASYNC_HTTP_PATCH;
   } else if(m == "HEAD"){
-    _method = HTTP_HEAD;
+    _method = ASYNC_HTTP_HEAD;
   } else if(m == "OPTIONS"){
-    _method = HTTP_OPTIONS;
+    _method = ASYNC_HTTP_OPTIONS;
   }
 
   String g = String();
@@ -952,14 +952,14 @@ String AsyncWebServerRequest::urlDecode(const String& text) const {
 
 
 const char * AsyncWebServerRequest::methodToString() const {
-  if(_method == HTTP_ANY) return "ANY";
-  else if(_method & HTTP_GET) return "GET";
-  else if(_method & HTTP_POST) return "POST";
-  else if(_method & HTTP_DELETE) return "DELETE";
-  else if(_method & HTTP_PUT) return "PUT";
-  else if(_method & HTTP_PATCH) return "PATCH";
-  else if(_method & HTTP_HEAD) return "HEAD";
-  else if(_method & HTTP_OPTIONS) return "OPTIONS";
+  if(_method == ASYNC_HTTP_ANY) return "ANY";
+  else if(_method & ASYNC_HTTP_GET) return "GET";
+  else if(_method & ASYNC_HTTP_POST) return "POST";
+  else if(_method & ASYNC_HTTP_DELETE) return "DELETE";
+  else if(_method & ASYNC_HTTP_PUT) return "PUT";
+  else if(_method & ASYNC_HTTP_PATCH) return "PATCH";
+  else if(_method & ASYNC_HTTP_HEAD) return "HEAD";
+  else if(_method & ASYNC_HTTP_OPTIONS) return "OPTIONS";
   return "UNKNOWN";
 }
 


### PR DESCRIPTION
I was trying to combine FauxMo which uses this library, and https://github.com/tzapu/WiFiManager
which uses ESP8266WebServer.h. Unfortunately there is a clash over the HTTP_* enums.

This PR renames them to allow the two headers (this and ESP8266WebServer.h) to be
used in the same project.