### PR TITLE
Disabled request body parsing if the handler does nothing.

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -322,6 +322,7 @@ class AsyncWebHandler {
     virtual void handleRequest(AsyncWebServerRequest *request __attribute__((unused))){}
     virtual void handleUpload(AsyncWebServerRequest *request  __attribute__((unused)), const String& filename __attribute__((unused)), size_t index __attribute__((unused)), uint8_t *data __attribute__((unused)), size_t len __attribute__((unused)), bool final  __attribute__((unused))){}
     virtual void handleBody(AsyncWebServerRequest *request __attribute__((unused)), uint8_t *data __attribute__((unused)), size_t len __attribute__((unused)), size_t index __attribute__((unused)), size_t total __attribute__((unused))){}
+    virtual bool isRequestHandlerTrivial(){return true;}
 };
 
 /*

--- a/src/SPIFFSEditor.h
+++ b/src/SPIFFSEditor.h
@@ -18,6 +18,7 @@ class SPIFFSEditor: public AsyncWebHandler {
     virtual bool canHandle(AsyncWebServerRequest *request) override final;
     virtual void handleRequest(AsyncWebServerRequest *request) override final;
     virtual void handleUpload(AsyncWebServerRequest *request, const String& filename, size_t index, uint8_t *data, size_t len, bool final) override final;
+    virtual bool isRequestHandlerTrivial() override final {return false;}
 };
 
 #endif

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -104,6 +104,7 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
       if(_onBody)
         _onBody(request, data, len, index, total);
     }
+    virtual bool isRequestHandlerTrivial() override final {return _onRequest ? false : true;}
 };
 
 #endif /* ASYNCWEBSERVERHANDLERIMPL_H_ */


### PR DESCRIPTION
This will save memory and prevent crashes on large POST requests.

Signed-off-by: Alexandr Zarubkin <me21@yandex.ru>