### PR TITLE
fix makeBuffer example to avoid memory corruption

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,7 +1029,7 @@ void sendDataWs(AsyncWebSocketClient * client)
     root["d"] = "abcdef";
     root["e"] = "abcdefg";
     size_t len = root.measureLength();
-    AsyncWebSocketMessageBuffer * buffer = ws.makeBuffer(len); //  creates a buffer (len + 1) for you.
+    AsyncWebSocketMessageBuffer * buffer = ws.makeBuffer(len + 1); //  creates a buffer (len + 1) for you.
     if (buffer) {
         root.printTo((char *)buffer->get(), len + 1);
         if (client) {


### PR DESCRIPTION
In Readme example, len bytes are allocated and len+1 bytes are written : memory corruption