### PR TITLE
Allow to override default template placeholder value with #define during compilation

### DIFF
--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -59,7 +59,10 @@ class AsyncAbstractResponse: public AsyncWebServerResponse {
     virtual size_t _fillBuffer(uint8_t *buf __attribute__((unused)), size_t maxLen __attribute__((unused))) { return 0; }
 };
 
+#ifndef TEMPLATE_PLACEHOLDER
 #define TEMPLATE_PLACEHOLDER '%'
+#endif
+
 #define TEMPLATE_PARAM_NAME_LENGTH 32
 class AsyncFileResponse: public AsyncAbstractResponse {
   using File = fs::File;


### PR DESCRIPTION
There was a number of complaints from library users who needed to use the symbol of template placeholder in their data as-is. It seems that doubling the symbol (`%%` to get a single `%` in the output) doesn't work. While that should be fixed, the code of template engine is convoluted, so the proper fix might take some time.

This is a simple workaround: if the user #defines `TEMPLATE_PLACEHOLDER` during build, its value will be used. If not, default value of `%` is used.