### PR TITLE
Broke HTTP_Method out into a separate header for reuse with WebServer…

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -27,6 +27,7 @@
 #include "FS.h"
 
 #include "StringArray.h"
+#include "HTTP_Method.h"
 
 #ifdef ESP32
 #include <WiFi.h>
@@ -51,16 +52,6 @@ class AsyncStaticWebHandler;
 class AsyncCallbackWebHandler;
 class AsyncResponseStream;
 
-typedef enum {
-  HTTP_GET     = 0b00000001,
-  HTTP_POST    = 0b00000010,
-  HTTP_DELETE  = 0b00000100,
-  HTTP_PUT     = 0b00001000,
-  HTTP_PATCH   = 0b00010000,
-  HTTP_HEAD    = 0b00100000,
-  HTTP_OPTIONS = 0b01000000,
-  HTTP_ANY     = 0b01111111,
-} WebRequestMethod;
 typedef uint8_t WebRequestMethodComposite;
 typedef std::function<void(void)> ArDisconnectHandler;
 

--- a/src/HTTP_Method.h
+++ b/src/HTTP_Method.h
@@ -1,0 +1,15 @@
+#ifndef _HTTP_Method_H_
+#define _HTTP_Method_H_
+
+typedef enum {
+  HTTP_GET     = 0b00000001,
+  HTTP_POST    = 0b00000010,
+  HTTP_DELETE  = 0b00000100,
+  HTTP_PUT     = 0b00001000,
+  HTTP_PATCH   = 0b00010000,
+  HTTP_HEAD    = 0b00100000,
+  HTTP_OPTIONS = 0b01000000,
+  HTTP_ANY     = 0b01111111,
+} HTTPMethod;
+
+#endif /* _HTTP_Method_H_ */


### PR DESCRIPTION
…(esp32)
Equivalent to https://github.com/espressif/arduino-esp32/pull/1562 for WebServer(esp32)
Fixes #373 