### PR TITLE
Add handlers by URL templates

### DIFF
--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -83,7 +83,13 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
       if(!(_method & request->method()))
         return false;
 
-      if(_uri.length() && (_uri != request->url() && !request->url().startsWith(_uri+"/")))
+      if (_uri.length() && _uri.endsWith("*")) {
+        String uriTemplate = String(_uri);
+        uriTemplate.replace("*", "");
+        if (!request->url().startsWith(uriTemplate))
+          return false;
+		  }
+      else if(_uri.length() && (_uri != request->url() && !request->url().startsWith(_uri+"/")))
         return false;
 
       request->addInterestingHeader("ANY");

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -85,10 +85,10 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
 
       if (_uri.length() && _uri.endsWith("*")) {
         String uriTemplate = String(_uri);
-        uriTemplate.replace("*", "");
+	uriTemplate = uriTemplate.substring(0, uriTemplate.length() - 1);
         if (!request->url().startsWith(uriTemplate))
           return false;
-		  }
+      }
       else if(_uri.length() && (_uri != request->url() && !request->url().startsWith(_uri+"/")))
         return false;
 


### PR DESCRIPTION
This change allows add handlers by URL templates. 
For example:
server.on("/gpio*", handleGpio);
server.on("/irsend*", handleIrsend);
The "handleGpio" handler will handle all requests starting with "/gpio" and manage all GPIOs.
The "handleGpio" handler will handle all requests starting with "/irsend" and forward commands to IR manager.