### PR TITLE
Allow override rewrite match

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -303,11 +303,13 @@ class AsyncWebRewrite {
         _toUrl = _toUrl.substring(0, index);
       }
     }
+    virtual ~AsyncWebRewrite(){}
     AsyncWebRewrite& setFilter(ArRequestFilterFunction fn) { _filter = fn; return *this; }
     bool filter(AsyncWebServerRequest *request) const { return _filter == NULL || _filter(request); }
     const String& from(void) const { return _from; }
     const String& toUrl(void) const { return _toUrl; }
     const String& params(void) const { return _params; }
+    virtual bool match(AsyncWebServerRequest *request) { return from() == request->url() && filter(request); }
 };
 
 /*

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -99,7 +99,7 @@ void AsyncWebServer::_handleDisconnect(AsyncWebServerRequest *request){
 
 void AsyncWebServer::_rewriteRequest(AsyncWebServerRequest *request){
   for(const auto& r: _rewrites){
-    if (r->from() == request->_url && r->filter(request)){
+    if (r->match(request)){
       request->_url = r->toUrl();
       request->_addGetParams(r->params());
     }


### PR DESCRIPTION
This PR allows override rewrite matching so you can implement more powerfull rewrites. One small imperfect example (it rewrites f.e. "/radio/{frequence}" -> "/radio?f={frequence}"):

```cpp
class OneParamRewrite : public AsyncWebRewrite
{
  protected:
    String _urlPrefix;
    int _paramIndex;
    String _paramsBackup;

  public:
  OneParamRewrite(const char* from, const char* to)
    : AsyncWebRewrite(from, to) {

      _paramIndex = _from.indexOf('{');

      if( _paramIndex >=0 && _from.endsWith("}")) {
        _urlPrefix = _from.substring(0, _paramIndex);
        int index = _params.indexOf('{');
        if(index >= 0) {
          _params = _params.substring(0, index);
        }
      } else {
        _urlPrefix = _from;
      }
      _paramsBackup = _params;
  }

  bool match(AsyncWebServerRequest *request) override {
    if(request->url().startsWith(_urlPrefix)) {
      if(_paramIndex >= 0) {
        _params = _paramsBackup + request->url().substring(_paramIndex);
      } else {
        _params = _paramsBackup;
      }
    return true;

    } else {
      return false;
    }
  }
};
```

Use:

```cpp
  server.addRewrite( new OneParamRewrite("/radio/{frequence}", "/radio?f={frequence}") );
```