### PR TITLE
Support route parameters with regex patterns 

### DIFF
--- a/examples/regex_patterns/regex_patterns.ino
+++ b/examples/regex_patterns/regex_patterns.ino
@@ -1,0 +1,60 @@
+//
+// A simple server implementation with regex routes:
+//  * serve static messages
+//  * read GET and POST parameters
+//  * handle missing pages / 404s
+//
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <AsyncTCP.h>
+#include <ESPAsyncWebServer.h>
+
+AsyncWebServer server(80);
+
+const char* ssid = "YOUR_SSID";
+const char* password = "YOUR_PASSWORD";
+
+const char* PARAM_MESSAGE = "message";
+
+void notFound(AsyncWebServerRequest *request) {
+    request->send(404, "text/plain", "Not found");
+}
+
+void setup() {
+
+    Serial.begin(115200);
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(ssid, password);
+    if (WiFi.waitForConnectResult() != WL_CONNECTED) {
+        Serial.printf("WiFi Failed!\n");
+        return;
+    }
+
+    Serial.print("IP Address: ");
+    Serial.println(WiFi.localIP());
+
+    server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
+        request->send(200, "text/plain", "Hello, world");
+    });
+
+    // Send a GET request to <IP>/sensor/<number>
+    server.on("^\\/sensor\\/([0-9]+)$", HTTP_GET, [] (AsyncWebServerRequest *request) {
+        String sensorNumber = request->pathArg(0);
+        request->send(200, "text/plain", "Hello, sensor: " + sensorNumber);
+    });
+	
+	// Send a GET request to <IP>/sensor/<number>/action/<action>
+    server.on("^\\/sensor\\/([0-9]+)\\/action\//([a-zA-Z0-9]+)$", HTTP_GET, [] (AsyncWebServerRequest *request) {
+        String sensorNumber = request->pathArg(0);
+        String action = request->pathArg(1);
+        request->send(200, "text/plain", "Hello, sensor: " + sensorNumber + ", with action: " + action);
+    });
+
+    server.onNotFound(notFound);
+
+    server.begin();
+}
+
+void loop() {
+}

--- a/src/AsyncJson.h
+++ b/src/AsyncJson.h
@@ -36,7 +36,7 @@
 #define ASYNC_JSON_H_
 #include <ArduinoJson.h>
 
-const char* JSON_MIMETYPE = "application/json";
+constexpr char* JSON_MIMETYPE = "application/json";
 
 /*
  * Json Response

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -129,6 +129,7 @@ class AsyncWebServerRequest {
   using File = fs::File;
   using FS = fs::FS;
   friend class AsyncWebServer;
+  friend class AsyncCallbackWebHandler;
   private:
     AsyncClient* _client;
     AsyncWebServer* _server;
@@ -158,6 +159,7 @@ class AsyncWebServerRequest {
 
     LinkedList<AsyncWebHeader *> _headers;
     LinkedList<AsyncWebParameter *> _params;
+    LinkedList<String *> _pathParams;
 
     uint8_t _multiParseState;
     uint8_t _boundaryPosition;
@@ -179,6 +181,7 @@ class AsyncWebServerRequest {
     void _onData(void *buf, size_t len);
 
     void _addParam(AsyncWebParameter*);
+    void _addPathParam(const char *param);
 
     bool _parseReqHead();
     bool _parseReqHeader();
@@ -267,6 +270,8 @@ class AsyncWebServerRequest {
     const String& argName(size_t i) const;       // get request argument name by number
     bool hasArg(const char* name) const;         // check if argument exists
     bool hasArg(const __FlashStringHelper * data) const;         // check if F(argument) exists
+
+    const String& pathArg(size_t i) const;
 
     const String& header(const char* name) const;// get request header value by name
     const String& header(const __FlashStringHelper * data) const;// get request header value by F(name)    

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -70,21 +70,11 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
     ArUploadHandlerFunction _onUpload;
     ArBodyHandlerFunction _onBody;
     bool _isRegex;
-    uint8_t _pathArgsSize;
   public:
-    AsyncCallbackWebHandler() : _uri(), _method(HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL), _pathArgsSize(0), __isRegex(false){}
+    AsyncCallbackWebHandler() : _uri(), _method(HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL), _isRegex(false){}
     void setUri(const String& uri){ 
       _uri = uri; 
        _isRegex = uri.startsWith("^") && uri.endsWith("$");
-      if (_isRegex) {
-          std::regex rgx((_uri + "|").c_str());
-          std::smatch matches;
-          std::string s{""};
-          std::regex_search(s, matches, rgx);
-          _pathArgsSize = matches.size() - 1;
-      } else {
-          _pathArgsSize = 0;
-      }
     }
     void setMethod(WebRequestMethodComposite method){ _method = method; }
     void onRequest(ArRequestHandlerFunction fn){ _onRequest = fn; }
@@ -100,19 +90,16 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
         return false;
 
       if (_isRegex) {
-          unsigned int pathArgIndex = 0;
-          std::regex rgx(_uri.c_str());
-          std::smatch matches;
-          std::string s(request->url().c_str());
-          if(std::regex_search(s, matches, rgx)) {
-              request->pathArgsInit(_pathArgsSize);
-              for (size_t i = 1; i < matches.size(); ++i) { // start from 1
-                  // pathArgs[pathArgIndex] = String(matches[i].str().c_str());
-                  // pathArgIndex++;
-              }
-          } else {
-            return false;
+        std::regex rgx(_uri.c_str());
+        std::smatch matches;
+        std::string s(request->url().c_str());
+        if(std::regex_search(s, matches, rgx)) {
+          for (size_t i = 1; i < matches.size(); ++i) { // start from 1
+            request->_addPathParam(matches[i].str().c_str());
           }
+        } else {
+          return false;
+        }
       } else if (_uri.length() && _uri.endsWith("*")) {
         String uriTemplate = String(_uri);
 	uriTemplate = uriTemplate.substring(0, uriTemplate.length() - 1);

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -55,6 +55,7 @@ AsyncWebServerRequest::AsyncWebServerRequest(AsyncWebServer* s, AsyncClient* c)
   , _parsedLength(0)
   , _headers(LinkedList<AsyncWebHeader *>([](AsyncWebHeader *h){ delete h; }))
   , _params(LinkedList<AsyncWebParameter *>([](AsyncWebParameter *p){ delete p; }))
+  , _pathParams(LinkedList<String *>([](String *p){ delete p; }))
   , _multiParseState(0)
   , _boundaryPosition(0)
   , _itemStartIndex(0)
@@ -80,6 +81,7 @@ AsyncWebServerRequest::~AsyncWebServerRequest(){
   _headers.free();
 
   _params.free();
+  _pathParams.free();
 
   _interestingHeaders.free();
 
@@ -228,6 +230,10 @@ void AsyncWebServerRequest::_onDisconnect(){
 
 void AsyncWebServerRequest::_addParam(AsyncWebParameter *p){
   _params.add(p);
+}
+
+void AsyncWebServerRequest::_addPathParam(const char *p){
+  _pathParams.add(new String(p));
 }
 
 void AsyncWebServerRequest::_addGetParams(const String& params){
@@ -910,6 +916,11 @@ const String& AsyncWebServerRequest::arg(size_t i) const {
 
 const String& AsyncWebServerRequest::argName(size_t i) const {
   return getParam(i)->name();
+}
+
+const String& AsyncWebServerRequest::pathArg(size_t i) const {
+  auto param = _pathParams.nth(i);
+  return param ? **param : SharedEmptyString;
 }
 
 const String& AsyncWebServerRequest::header(const char* name) const {


### PR DESCRIPTION
Add regex pattern as URL with parameters.
Example:
```
webserver.on("^\\/users\\/([0-9]+)\\/devices\\/([0-9]+)$", [](AsyncWebServerRequest *request) {
  String user =  request->pathArg(0);
  String device =  request->pathArg(1);
  request->send(200, "text/html", "<h1>USER " + user + " AND DEVICE " + device + "</h1>");
});
```

This is a draft version. It gives an impression of the functionality.
Help and/or advice needed to finalize.
