### PR TITLE
Adjust canHandle() for AsyncEventSource

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -307,8 +307,9 @@ size_t AsyncEventSource::count() const {
 }
 
 bool AsyncEventSource::canHandle(AsyncWebServerRequest *request){
-  if(request->method() != HTTP_GET || !request->url().equals(_url) || !request->isExpectedRequestedConnType(RCT_EVENT))
+  if(request->method() != HTTP_GET || !request->url().equals(_url)) {
     return false;
+  }
   request->addInterestingHeader("Last-Event-ID");
   return true;
 }


### PR DESCRIPTION
Neither `curl` nor a web browser can access an event stream because they do not send `expected request connect types` (so the event source handler is skipped). I assume the way `curl` and web browsers work is standard, so we can simply remove the condition `request->isExpectedRequestedConnType(RCT_EVENT)`.