### PR TITLE
Fix sha1 not defined compilation error

### DIFF
--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -31,6 +31,10 @@
 #endif
 #include <ESPAsyncWebServer.h>
 
+#ifdef ESP8266
+#include <Hash.h>
+#endif
+
 class AsyncWebSocket;
 class AsyncWebSocketResponse;
 class AsyncWebSocketClient;


### PR DESCRIPTION
With ESP8266 Arduino core 2.5.2 I was getting a compilation error related to sha1() function. Hash.h was not included.
After adding it to AsyncWebSocket.h code compiles fine.
I'm using Visual Studio 2019 with VisualMicro 1906.16.1