### PR TITLE
Add thread locking to improve stability.

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1197,6 +1197,7 @@ AsyncWebSocketMessageBuffer * AsyncWebSocket::makeBuffer(size_t size)
 {
   AsyncWebSocketMessageBuffer * buffer = new AsyncWebSocketMessageBuffer(size); 
   if (buffer) {
+    AsyncWebLockGuard l(_lock);
     _buffers.add(buffer);
   }
   return buffer; 
@@ -1207,6 +1208,7 @@ AsyncWebSocketMessageBuffer * AsyncWebSocket::makeBuffer(uint8_t * data, size_t 
   AsyncWebSocketMessageBuffer * buffer = new AsyncWebSocketMessageBuffer(data, size); 
   
   if (buffer) {
+    AsyncWebLockGuard l(_lock);
     _buffers.add(buffer);
   }
 
@@ -1215,6 +1217,7 @@ AsyncWebSocketMessageBuffer * AsyncWebSocket::makeBuffer(uint8_t * data, size_t 
 
 void AsyncWebSocket::_cleanBuffers()
 {
+  AsyncWebLockGuard l(_lock);
   for(AsyncWebSocketMessageBuffer * c: _buffers){
     if(c && c->canDelete()){
         _buffers.remove(c);

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -31,6 +31,8 @@
 #endif
 #include <ESPAsyncWebServer.h>
 
+#include "AsyncWebSynchronization.h"
+
 #ifdef ESP8266
 #include <Hash.h>
 #endif
@@ -236,6 +238,7 @@ class AsyncWebSocket: public AsyncWebHandler {
     uint32_t _cNextId;
     AwsEventHandler _eventHandler;
     bool _enabled;
+	AsyncWebLock _lock;
   public:
     AsyncWebSocket(const String& url);
     ~AsyncWebSocket();

--- a/src/AsyncWebSynchronization.h
+++ b/src/AsyncWebSynchronization.h
@@ -1,0 +1,60 @@
+#ifndef ASYNCWEBSYNCHRONIZATION_H_
+#define ASYNCWEBSYNCHRONIZATION_H_
+
+#include <ESPAsyncWebServer.h>
+
+class AsyncWebLock
+{
+private:
+  SemaphoreHandle_t _lock;
+  mutable void *_lockedBy;
+
+public:
+  AsyncWebLock() {
+    _lock = xSemaphoreCreateBinary();
+    _lockedBy = NULL;
+    xSemaphoreGive(_lock);
+  }
+
+  ~AsyncWebLock() {
+    vSemaphoreDelete(_lock);
+  }
+
+  bool lock() const {
+    extern void *pxCurrentTCB;
+    if (_lockedBy != pxCurrentTCB) {
+      xSemaphoreTake(_lock, portMAX_DELAY);
+      _lockedBy = pxCurrentTCB;
+      return true;
+    }
+    return false;
+  }
+
+  void unlock() const {
+    _lockedBy = NULL;
+    xSemaphoreGive(_lock);
+  }
+};
+
+class AsyncWebLockGuard
+{
+private:
+  const AsyncWebLock *_lock;
+
+public:
+  AsyncWebLockGuard(const AsyncWebLock &l) {
+    if (l.lock()) {
+      _lock = &l;
+    } else {
+      _lock = NULL;
+    }
+  }
+
+  ~AsyncWebLockGuard() {
+    if (_lock) {
+      _lock->unlock();
+    }
+  }
+};
+
+#endif // ASYNCWEBSYNCHRONIZATION_H_


### PR DESCRIPTION
If you use web-sockets you get frequent heap corruption errors.  By a process of trail and error I have tracked this down to the websocket buffer.

As far as I can tell the websocket class is access by 2 different threads, the application thread and the tcpip thread.  Normally this is fine because thread synchronisation is handled by message queues.  

However, the websocket buffer linked list is used by both threads and a race condition exists which will cause heap corruption if a buffer is being created by the application when at the same time one is being consumed by the tcpip thread.

This patch adds thread safety to the websocket buffer linked list.  It shouldn't add too much overhead to the websocket implementation as the locks are only in place for a relatively short time and they are only used on construction and destruction of a websocket buffer.

