### PR TITLE
Remove extra #endif

### DIFF
--- a/src/AsyncJson.h
+++ b/src/AsyncJson.h
@@ -162,7 +162,6 @@ public:
 		return len;
 	}
 };
-#endif
 
 typedef std::function<void(AsyncWebServerRequest *request, JsonVariant &json)> ArJsonRequestHandlerFunction;
 


### PR DESCRIPTION
59066bd1e4b51bc3a161e94adce10a89cde0a616 moved a few `#ifedf`s and `#endif`s around and seems to have missed one. This fixes.