### PR TITLE
Fixes #614 with incorrect regex in the example sketch

### DIFF
--- a/examples/regex_patterns/regex_patterns.ino
+++ b/examples/regex_patterns/regex_patterns.ino
@@ -50,7 +50,7 @@ void setup() {
     });
 	
 	// Send a GET request to <IP>/sensor/<number>/action/<action>
-    server.on("^\\/sensor\\/([0-9]+)\\/action\//([a-zA-Z0-9]+)$", HTTP_GET, [] (AsyncWebServerRequest *request) {
+    server.on("^\\/sensor\\/([0-9]+)\\/action\\/([a-zA-Z0-9]+)$", HTTP_GET, [] (AsyncWebServerRequest *request) {
         String sensorNumber = request->pathArg(0);
         String action = request->pathArg(1);
         request->send(200, "text/plain", "Hello, sensor: " + sensorNumber + ", with action: " + action);


### PR DESCRIPTION
Incorrect escape of backslash in regex_patterns.ino sketch. Verified on one of my ESP32's
