### PR TITLE
AsyncEvents/ServerSideEvents: prevent internal DOS by prevent overflowing messageQueue

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -184,10 +184,14 @@ void AsyncEventSourceClient::_queueMessage(AsyncEventSourceMessage *dataMessage)
     delete dataMessage;
     return;
   }
-
-  _messageQueue.add(dataMessage);
-
-  _runQueue();
+  if(_messageQueue.length() >= SSE_MAX_QUEUED_MESSAGES){
+      ets_printf("ERROR: Too many messages queued\n");
+      delete dataMessage;
+  } else {
+      _messageQueue.add(dataMessage);
+  }
+  if(_client->canSend())
+    _runQueue();
 }
 
 void AsyncEventSourceClient::_onAck(size_t len, uint32_t time){

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -23,10 +23,27 @@
 #include <Arduino.h>
 #ifdef ESP32
 #include <AsyncTCP.h>
+#define SSE_MAX_QUEUED_MESSAGES 32
 #else
 #include <ESPAsyncTCP.h>
+#define SSE_MAX_QUEUED_MESSAGES 8
 #endif
 #include <ESPAsyncWebServer.h>
+
+#include "AsyncWebSynchronization.h"
+
+#ifdef ESP8266
+#include <Hash.h>
+#ifdef CRYPTO_HASH_h // include Hash.h from espressif framework if the first include was from the crypto library
+#include <../src/Hash.h>
+#endif
+#endif
+
+#ifdef ESP32
+#define DEFAULT_MAX_WS_CLIENTS 8
+#else
+#define DEFAULT_MAX_WS_CLIENTS 4
+#endif
 
 class AsyncEventSource;
 class AsyncEventSourceResponse;

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -40,9 +40,9 @@
 #endif
 
 #ifdef ESP32
-#define DEFAULT_MAX_WS_CLIENTS 8
+#define DEFAULT_MAX_SSE_CLIENTS 8
 #else
-#define DEFAULT_MAX_WS_CLIENTS 4
+#define DEFAULT_MAX_SSE_CLIENTS 4
 #endif
 
 class AsyncEventSource;


### PR DESCRIPTION
Hi,
First of all I think the AsyncEvents is not SMP safe, and crashes a lot when stressed a bit.

This pull request adresses only one issue, basically copied solution from the websockets code.
In case a SSE client is connected, and messages are generated rapidly, the ESP32 WiFi/tcpip stack will lockup when the wifi connection(distance) is getting worse. _messageQueue is completely filled up, basically denial of service to the TCP stack.
WDT goes off when not disabled.

I copied the include part from web sockets include, rename the WS -defines to SSE-defines, and changed queing code, now queue is filled up until a certain level, most recent messages are dropped above, instead wildly stressing tcp stack.

I see the web Sockets have a controll queue, which i think is required for serverside events (AsyncEvents) too , but do not know yet how to start on that. In meanwhile this patch solved the most annoying lockup of wifi/tcpstack (in my case)