### PR TITLE
Fixed compile issue with SPIFFSEditor.cpp for ESP8266

### DIFF
--- a/src/SPIFFSEditor.cpp
+++ b/src/SPIFFSEditor.cpp
@@ -442,7 +442,7 @@ void SPIFFSEditor::handleRequest(AsyncWebServerRequest *request){
 #ifdef ESP32
       File dir = _fs.open(path);
 #else
-      Dir dir = _fs.openDir(path);
+      fs::Dir dir = _fs.openDir(path);
 #endif
       path = String();
       String output = "[";


### PR DESCRIPTION
This PR fixes a compile issue for SPIFFSEditor.cpp, when used for `espressif8266` platform. 

```
.pio\libdeps\nodemcuv2\ESP Async WebServer_ID306\src\SPIFFSEditor.cpp: In member function 'virtual void SPIFFSEditor::handleRequest(AsyncWebServerRequest*)':
.pio\libdeps\nodemcuv2\ESP Async WebServer_ID306\src\SPIFFSEditor.cpp:445:7: error: 'Dir' was not declared in this scope
       Dir dir = _fs.openDir(path);
       ^
.pio\libdeps\nodemcuv2\ESP Async WebServer_ID306\src\SPIFFSEditor.cpp:445:7: note: suggested alternative:
In file included from .pio\libdeps\nodemcuv2\ESP Async WebServer_ID306\src/ESPAsyncWebServer.h:27:0,
                 from .pio\libdeps\nodemcuv2\ESP Async WebServer_ID306\src\SPIFFSEditor.h:3,
                 from .pio\libdeps\nodemcuv2\ESP Async WebServer_ID306\src\SPIFFSEditor.cpp:1:
C:\Users\Amente\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/FS.h:81:7: note:   'fs::Dir'
 class Dir {
       ^
.pio\libdeps\nodemcuv2\ESP Async WebServer_ID306\src\SPIFFSEditor.cpp:445:11: error: expected ';' before 'dir'
       Dir dir = _fs.openDir(path);
           ^
.pio\libdeps\nodemcuv2\ESP Async WebServer_ID306\src\SPIFFSEditor.cpp:453:13: error: 'dir' was not declared in this scope
       while(dir.next()){
             ^
*** [.pio\build\nodemcuv2\lib728\ESP Async WebServer_ID306\SPIFFSEditor.cpp.o] Error 1
```