### PR TITLE
Added support for webdav http methods

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -59,21 +59,29 @@ class AsyncResponseStream;
 
 #ifndef WEBSERVER_H
 typedef enum {
-  HTTP_GET     = 0b00000001,
-  HTTP_POST    = 0b00000010,
-  HTTP_DELETE  = 0b00000100,
-  HTTP_PUT     = 0b00001000,
-  HTTP_PATCH   = 0b00010000,
-  HTTP_HEAD    = 0b00100000,
-  HTTP_OPTIONS = 0b01000000,
-  HTTP_ANY     = 0b01111111,
+  HTTP_GET       = 0b0000000000000001,
+  HTTP_POST      = 0b0000000000000010,
+  HTTP_DELETE    = 0b0000000000000100,
+  HTTP_PUT       = 0b0000000000001000,
+  HTTP_PATCH     = 0b0000000000010000,
+  HTTP_HEAD      = 0b0000000000100000,
+  HTTP_OPTIONS   = 0b0000000001000000,
+  HTTP_PROPFIND  = 0b0000000010000000,
+  HTTP_LOCK      = 0b0000000100000000,
+  HTTP_UNLOCK    = 0b0000001000000000,
+  HTTP_PROPPATCH = 0b0000010000000000,
+  HTTP_MKCOL     = 0b0000100000000000,
+  HTTP_MOVE      = 0b0001000000000000,
+  HTTP_COPY      = 0b0010000000000000,
+  HTTP_RESERVED  = 0b0100000000000000,
+  HTTP_ANY       = 0b0111111111111111,
 } WebRequestMethod;
 #endif
 
 //if this value is returned when asked for data, packet will not be sent and you will be asked for data again
 #define RESPONSE_TRY_AGAIN 0xFFFFFFFF
 
-typedef uint8_t WebRequestMethodComposite;
+typedef uint16_t WebRequestMethodComposite;
 typedef std::function<void(void)> ArDisconnectHandler;
 
 /*

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -273,6 +273,22 @@ bool AsyncWebServerRequest::_parseReqHead(){
     _method = HTTP_HEAD;
   } else if(m == "OPTIONS"){
     _method = HTTP_OPTIONS;
+  } else if(m == "PROPFIND"){
+    _method = HTTP_PROPFIND;
+  } else if(m == "LOCK"){
+    _method = HTTP_LOCK;
+  } else if(m == "UNLOCK"){
+    _method = HTTP_UNLOCK;
+  } else if(m == "PROPPATCH"){
+    _method = HTTP_PROPPATCH;
+  } else if(m == "MKCOL"){
+    _method = HTTP_MKCOL;
+  } else if(m == "MOVE"){
+    _method = HTTP_MOVE;
+  } else if(m == "ANY"){
+    _method = HTTP_ANY;
+  }else{
+    _method = HTTP_VERBFAIL;
   }
 
   String g = String();
@@ -985,6 +1001,14 @@ const char * AsyncWebServerRequest::methodToString() const {
   else if(_method & HTTP_PATCH) return "PATCH";
   else if(_method & HTTP_HEAD) return "HEAD";
   else if(_method & HTTP_OPTIONS) return "OPTIONS";
+  else if(_method & HTTP_PROPFIND) return "PROPFIND";
+  else if(_method & HTTP_LOCK) return "LOCK";
+  else if(_method & HTTP_UNLOCK) return "UNLOCK";
+  else if(_method & HTTP_PROPPATCH) return "PROPPATCH";
+  else if(_method & HTTP_MKCOL) return "MKCOL";
+  else if(_method & HTTP_MOVE) return "MOVE";
+  else if(_method & HTTP_COPY) return "COPY";
+  else if(_method & HTTP_RESERVED) return "RESERVED";
   return "UNKNOWN";
 }
 


### PR DESCRIPTION
### Reason for the PR
I am currently working on a webdav server using ESPAsyncWebServer. Since the request method is not a string, the enum needed to be extended by some additional methods.

### What I've changed
- Changed WebRequestMethodComposite from uint8_t to uint16_t
- Added support for PROPFIND, LOCK, UNLOCK, PROPPATCH, MKCOL, MOVE, COPY
- Added a method RESERVED which is currently not needed (could be removed)