### PR TITLE
Encapsulate WebRequestMethod to AsyncWebServerMethods

### DIFF
--- a/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
+++ b/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
@@ -146,7 +146,7 @@ void setup(){
   server.addHandler(new SPIFFSEditor(http_username,http_password));
 #endif
   
-  server.on("/heap", HTTP_GET, [](AsyncWebServerRequest *request){
+  server.on("/heap", AsyncWebServerMethods::HTTP_GET, [](AsyncWebServerRequest *request){
     request->send(200, "text/plain", String(ESP.getFreeHeap()));
   });
 
@@ -154,19 +154,19 @@ void setup(){
 
   server.onNotFound([](AsyncWebServerRequest *request){
     Serial.printf("NOT_FOUND: ");
-    if(request->method() == HTTP_GET)
+    if(request->method() == AsyncWebServerMethods::HTTP_GET)
       Serial.printf("GET");
-    else if(request->method() == HTTP_POST)
+    else if(request->method() == AsyncWebServerMethods::HTTP_POST)
       Serial.printf("POST");
-    else if(request->method() == HTTP_DELETE)
+    else if(request->method() == AsyncWebServerMethods::HTTP_DELETE)
       Serial.printf("DELETE");
-    else if(request->method() == HTTP_PUT)
+    else if(request->method() == AsyncWebServerMethods::HTTP_PUT)
       Serial.printf("PUT");
-    else if(request->method() == HTTP_PATCH)
+    else if(request->method() == AsyncWebServerMethods::HTTP_PATCH)
       Serial.printf("PATCH");
-    else if(request->method() == HTTP_HEAD)
+    else if(request->method() == AsyncWebServerMethods::HTTP_HEAD)
       Serial.printf("HEAD");
-    else if(request->method() == HTTP_OPTIONS)
+    else if(request->method() == AsyncWebServerMethods::HTTP_OPTIONS)
       Serial.printf("OPTIONS");
     else
       Serial.printf("UNKNOWN");

--- a/examples/regex_patterns/regex_patterns.ino
+++ b/examples/regex_patterns/regex_patterns.ino
@@ -51,18 +51,18 @@ void setup() {
     Serial.print("IP Address: ");
     Serial.println(WiFi.localIP());
 
-    server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
+    server.on("/", AsyncWebServerMethods::HTTP_GET, [](AsyncWebServerRequest *request){
         request->send(200, "text/plain", "Hello, world");
     });
 
     // Send a GET request to <IP>/sensor/<number>
-    server.on("^\\/sensor\\/([0-9]+)$", HTTP_GET, [] (AsyncWebServerRequest *request) {
+    server.on("^\\/sensor\\/([0-9]+)$", AsyncWebServerMethods::HTTP_GET, [] (AsyncWebServerRequest *request) {
         String sensorNumber = request->pathArg(0);
         request->send(200, "text/plain", "Hello, sensor: " + sensorNumber);
     });
 	
 	// Send a GET request to <IP>/sensor/<number>/action/<action>
-    server.on("^\\/sensor\\/([0-9]+)\\/action\\/([a-zA-Z0-9]+)$", HTTP_GET, [] (AsyncWebServerRequest *request) {
+    server.on("^\\/sensor\\/([0-9]+)\\/action\\/([a-zA-Z0-9]+)$", AsyncWebServerMethods::HTTP_GET, [] (AsyncWebServerRequest *request) {
         String sensorNumber = request->pathArg(0);
         String action = request->pathArg(1);
         request->send(200, "text/plain", "Hello, sensor: " + sensorNumber + ", with action: " + action);

--- a/examples/simple_server/simple_server.ino
+++ b/examples/simple_server/simple_server.ino
@@ -39,12 +39,12 @@ void setup() {
     Serial.print("IP Address: ");
     Serial.println(WiFi.localIP());
 
-    server.on("/", HTTP_GET, [](AsyncWebServerRequest *request){
+    server.on("/", AsyncWebServerMethods::HTTP_GET, [](AsyncWebServerRequest *request){
         request->send(200, "text/plain", "Hello, world");
     });
 
     // Send a GET request to <IP>/get?message=<message>
-    server.on("/get", HTTP_GET, [] (AsyncWebServerRequest *request) {
+    server.on("/get", AsyncWebServerMethods::HTTP_GET, [] (AsyncWebServerRequest *request) {
         String message;
         if (request->hasParam(PARAM_MESSAGE)) {
             message = request->getParam(PARAM_MESSAGE)->value();
@@ -55,7 +55,7 @@ void setup() {
     });
 
     // Send a POST request to <IP>/post with a form field message set to <message>
-    server.on("/post", HTTP_POST, [](AsyncWebServerRequest *request){
+    server.on("/post", AsyncWebServerMethods::HTTP_POST, [](AsyncWebServerRequest *request){
         String message;
         if (request->hasParam(PARAM_MESSAGE, true)) {
             message = request->getParam(PARAM_MESSAGE, true)->value();

--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -329,7 +329,7 @@ size_t AsyncEventSource::count() const {
 }
 
 bool AsyncEventSource::canHandle(AsyncWebServerRequest *request){
-  if(request->method() != HTTP_GET || !request->url().equals(_url)) {
+  if(request->method() != AsyncWebServerMethods::HTTP_GET || !request->url().equals(_url)) {
     return false;
   }
   request->addInterestingHeader("Last-Event-ID");

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1169,7 +1169,7 @@ bool AsyncWebSocket::canHandle(AsyncWebServerRequest *request){
   if(!_enabled)
     return false;
   
-  if(request->method() != HTTP_GET || !request->url().equals(_url) || !request->isExpectedRequestedConnType(RCT_WS))
+  if(request->method() != AsyncWebServerMethods::HTTP_GET || !request->url().equals(_url) || !request->isExpectedRequestedConnType(RCT_WS))
     return false;
 
   request->addInterestingHeader(WS_STR_CONNECTION);

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -58,16 +58,18 @@ class AsyncCallbackWebHandler;
 class AsyncResponseStream;
 
 #ifndef WEBSERVER_H
-typedef enum {
-  HTTP_GET     = 0b00000001,
-  HTTP_POST    = 0b00000010,
-  HTTP_DELETE  = 0b00000100,
-  HTTP_PUT     = 0b00001000,
-  HTTP_PATCH   = 0b00010000,
-  HTTP_HEAD    = 0b00100000,
-  HTTP_OPTIONS = 0b01000000,
-  HTTP_ANY     = 0b01111111,
-} WebRequestMethod;
+struct AsyncWebServerMethods {
+	typedef enum {
+	  HTTP_GET     = 0b00000001,
+	  HTTP_POST    = 0b00000010,
+	  HTTP_DELETE  = 0b00000100,
+	  HTTP_PUT     = 0b00001000,
+	  HTTP_PATCH   = 0b00010000,
+	  HTTP_HEAD    = 0b00100000,
+	  HTTP_OPTIONS = 0b01000000,
+	  HTTP_ANY     = 0b01111111,
+	} WebRequestMethod;
+};
 #endif
 
 //if this value is returned when asked for data, packet will not be sent and you will be asked for data again

--- a/src/SPIFFSEditor.cpp
+++ b/src/SPIFFSEditor.cpp
@@ -390,7 +390,7 @@ SPIFFSEditor::SPIFFSEditor(const String& username, const String& password, const
 
 bool SPIFFSEditor::canHandle(AsyncWebServerRequest *request){
   if(request->url().equalsIgnoreCase("/edit")){
-    if(request->method() == HTTP_GET){
+    if(request->method() == AsyncWebServerMethods::HTTP_GET){
       if(request->hasParam("list"))
         return true;
       if(request->hasParam("edit")){
@@ -420,11 +420,11 @@ bool SPIFFSEditor::canHandle(AsyncWebServerRequest *request){
       request->addInterestingHeader("If-Modified-Since");
       return true;
     }
-    else if(request->method() == HTTP_POST)
+    else if(request->method() == AsyncWebServerMethods::HTTP_POST)
       return true;
-    else if(request->method() == HTTP_DELETE)
+    else if(request->method() == AsyncWebServerMethods::HTTP_DELETE)
       return true;
-    else if(request->method() == HTTP_PUT)
+    else if(request->method() == AsyncWebServerMethods::HTTP_PUT)
       return true;
 
   }
@@ -436,7 +436,7 @@ void SPIFFSEditor::handleRequest(AsyncWebServerRequest *request){
   if(_username.length() && _password.length() && !request->authenticate(_username.c_str(), _password.c_str()))
     return request->requestAuthentication();
 
-  if(request->method() == HTTP_GET){
+  if(request->method() == AsyncWebServerMethods::HTTP_GET){
     if(request->hasParam("list")){
       String path = request->getParam("list")->value();
 #ifdef ESP32
@@ -494,18 +494,18 @@ void SPIFFSEditor::handleRequest(AsyncWebServerRequest *request){
         request->send(response);
       }
     }
-  } else if(request->method() == HTTP_DELETE){
+  } else if(request->method() == AsyncWebServerMethods::HTTP_DELETE){
     if(request->hasParam("path", true)){
         _fs.remove(request->getParam("path", true)->value());
       request->send(200, "", "DELETE: "+request->getParam("path", true)->value());
     } else
       request->send(404);
-  } else if(request->method() == HTTP_POST){
+  } else if(request->method() == AsyncWebServerMethods::HTTP_POST){
     if(request->hasParam("data", true, true) && _fs.exists(request->getParam("data", true, true)->value()))
       request->send(200, "", "UPLOADED: "+request->getParam("data", true, true)->value());
     else
       request->send(500);
-  } else if(request->method() == HTTP_PUT){
+  } else if(request->method() == AsyncWebServerMethods::HTTP_PUT){
     if(request->hasParam("path", true)){
       String filename = request->getParam("path", true)->value();
       if(_fs.exists(filename)){

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -73,7 +73,7 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
     ArBodyHandlerFunction _onBody;
     bool _isRegex;
   public:
-    AsyncCallbackWebHandler() : _uri(), _method(HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL), _isRegex(false) {}
+    AsyncCallbackWebHandler() : _uri(), _method(AsyncWebServerMethods::HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL), _isRegex(false) {}
     void setUri(const String& uri){ 
       _uri = uri; 
       _isRegex = uri.startsWith("^") && uri.endsWith("$");

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -81,7 +81,7 @@ AsyncStaticWebHandler& AsyncStaticWebHandler::setLastModified(){
 }
 #endif
 bool AsyncStaticWebHandler::canHandle(AsyncWebServerRequest *request){
-  if(request->method() != HTTP_GET 
+  if(request->method() != AsyncWebServerMethods::HTTP_GET 
     || !request->url().startsWith(_uri) 
     || !request->isExpectedRequestedConnType(RCT_DEFAULT, RCT_HTTP)
   ){

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -40,7 +40,7 @@ AsyncWebServerRequest::AsyncWebServerRequest(AsyncWebServer* s, AsyncClient* c)
   , _temp()
   , _parseState(0)
   , _version(0)
-  , _method(HTTP_ANY)
+  , _method(AsyncWebServerMethods::HTTP_ANY)
   , _url()
   , _host()
   , _contentType()
@@ -260,19 +260,19 @@ bool AsyncWebServerRequest::_parseReqHead(){
   _temp = _temp.substring(index+1);
 
   if(m == "GET"){
-    _method = HTTP_GET;
+    _method = AsyncWebServerMethods::HTTP_GET;
   } else if(m == "POST"){
-    _method = HTTP_POST;
+    _method = AsyncWebServerMethods::HTTP_POST;
   } else if(m == "DELETE"){
-    _method = HTTP_DELETE;
+    _method = AsyncWebServerMethods::HTTP_DELETE;
   } else if(m == "PUT"){
-    _method = HTTP_PUT;
+    _method = AsyncWebServerMethods::HTTP_PUT;
   } else if(m == "PATCH"){
-    _method = HTTP_PATCH;
+    _method = AsyncWebServerMethods::HTTP_PATCH;
   } else if(m == "HEAD"){
-    _method = HTTP_HEAD;
+    _method = AsyncWebServerMethods::HTTP_HEAD;
   } else if(m == "OPTIONS"){
-    _method = HTTP_OPTIONS;
+    _method = AsyncWebServerMethods::HTTP_OPTIONS;
   }
 
   String g = String();
@@ -977,14 +977,14 @@ String AsyncWebServerRequest::urlDecode(const String& text) const {
 
 
 const char * AsyncWebServerRequest::methodToString() const {
-  if(_method == HTTP_ANY) return "ANY";
-  else if(_method & HTTP_GET) return "GET";
-  else if(_method & HTTP_POST) return "POST";
-  else if(_method & HTTP_DELETE) return "DELETE";
-  else if(_method & HTTP_PUT) return "PUT";
-  else if(_method & HTTP_PATCH) return "PATCH";
-  else if(_method & HTTP_HEAD) return "HEAD";
-  else if(_method & HTTP_OPTIONS) return "OPTIONS";
+  if(_method == AsyncWebServerMethods::HTTP_ANY) return "ANY";
+  else if(_method & AsyncWebServerMethods::HTTP_GET) return "GET";
+  else if(_method & AsyncWebServerMethods::HTTP_POST) return "POST";
+  else if(_method & AsyncWebServerMethods::HTTP_DELETE) return "DELETE";
+  else if(_method & AsyncWebServerMethods::HTTP_PUT) return "PUT";
+  else if(_method & AsyncWebServerMethods::HTTP_PATCH) return "PATCH";
+  else if(_method & AsyncWebServerMethods::HTTP_HEAD) return "HEAD";
+  else if(_method & AsyncWebServerMethods::HTTP_OPTIONS) return "OPTIONS";
   return "UNKNOWN";
 }
 


### PR DESCRIPTION
Encapsulate WebRequestMethod to AsyncWebServerMethods to prevent HTTP Method redeclaration errors when used in combination with ESP8266WebServer