### PR TITLE
Add Custom Handshake Handlers for Websocket and EventSource Plugins

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -347,7 +347,7 @@ void AsyncEventSource::handleRequest(AsyncWebServerRequest *request){
   
   // If Custom Handshake Handler is supplied
   if(_handshakecb != nullptr){
-    if(_handshakecb()){
+    if(_handshakecb(request)){
       // Request Accepted
       request->send(new AsyncEventSourceResponse(this)); 
     }else{

--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -337,6 +337,7 @@ bool AsyncEventSource::canHandle(AsyncWebServerRequest *request){
     return false;
   }
   request->addInterestingHeader("Last-Event-ID");
+  request->addInterestingHeader("Cookie");
   return true;
 }
 

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -49,6 +49,7 @@ class AsyncEventSource;
 class AsyncEventSourceResponse;
 class AsyncEventSourceClient;
 typedef std::function<void(AsyncEventSourceClient *client)> ArEventHandlerFunction;
+typedef std::function<bool(AsyncWebServerRequest *request)> ArHandshakeHandlerFunction;
 
 class AsyncEventSourceMessage {
   private:
@@ -100,6 +101,7 @@ class AsyncEventSource: public AsyncWebHandler {
     String _url;
     LinkedList<AsyncEventSourceClient *> _clients;
     ArEventHandlerFunction _connectcb;
+    ArAuthHandlerFunction _authcb;
   public:
     AsyncEventSource(const String& url);
     ~AsyncEventSource();
@@ -107,6 +109,8 @@ class AsyncEventSource: public AsyncWebHandler {
     const char * url() const { return _url.c_str(); }
     void close();
     void onConnect(ArEventHandlerFunction cb);
+    void onHandshake(ArHandshakeHandlerFunction cb);
+  
     void send(const char *message, const char *event=NULL, uint32_t id=0, uint32_t reconnect=0);
     size_t count() const; //number clinets connected
     size_t  avgPacketsWaiting() const;

--- a/src/AsyncEventSource.h
+++ b/src/AsyncEventSource.h
@@ -101,7 +101,7 @@ class AsyncEventSource: public AsyncWebHandler {
     String _url;
     LinkedList<AsyncEventSourceClient *> _clients;
     ArEventHandlerFunction _connectcb;
-    ArAuthHandlerFunction _authcb;
+    ArHandshakeHandlerFunction _handshakecb;
   public:
     AsyncEventSource(const String& url);
     ~AsyncEventSource();

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1166,9 +1166,6 @@ const char * WS_STR_PROTOCOL = "Sec-WebSocket-Protocol";
 const char * WS_STR_ACCEPT = "Sec-WebSocket-Accept";
 const char * WS_STR_UUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
-void AsyncWebSocket::handleHandshake(AwsHandshakeHandler handler){
-  _handshakeHandler = handler;
-}
 
 bool AsyncWebSocket::canHandle(AsyncWebServerRequest *request){
   if(!_enabled)
@@ -1197,7 +1194,7 @@ void AsyncWebSocket::handleRequest(AsyncWebServerRequest *request){
   }
   
   if(_handshakeHandler != nullptr){
-    if(!_handshakeHandler(request){
+    if(!_handshakeHandler(request)){
       request->send(401);
       return;
     }

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1166,6 +1166,10 @@ const char * WS_STR_PROTOCOL = "Sec-WebSocket-Protocol";
 const char * WS_STR_ACCEPT = "Sec-WebSocket-Accept";
 const char * WS_STR_UUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 
+void AsyncWebSocket::handleHandshake(AwsHandshakeHandler handler){
+  _handshakeHandler = handler;
+}
+
 bool AsyncWebSocket::canHandle(AsyncWebServerRequest *request){
   if(!_enabled)
     return false;
@@ -1191,6 +1195,14 @@ void AsyncWebSocket::handleRequest(AsyncWebServerRequest *request){
   if((_username != "" && _password != "") && !request->authenticate(_username.c_str(), _password.c_str())){
     return request->requestAuthentication();
   }
+  
+  if(_handshakeHandler != nullptr){
+    if(!_handshakeHandler(&request){
+      request->send(401);
+      return;
+    }
+  }
+  
   AsyncWebHeader* version = request->getHeader(WS_STR_VERSION);
   if(version->value().toInt() != 13){
     AsyncWebServerResponse *response = request->beginResponse(400);

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1197,7 +1197,7 @@ void AsyncWebSocket::handleRequest(AsyncWebServerRequest *request){
   }
   
   if(_handshakeHandler != nullptr){
-    if(!_handshakeHandler(&request){
+    if(!_handshakeHandler(request){
       request->send(401);
       return;
     }

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1159,6 +1159,7 @@ void AsyncWebSocket::binaryAll(const __FlashStringHelper *message, size_t len){
 const char * WS_STR_CONNECTION = "Connection";
 const char * WS_STR_UPGRADE = "Upgrade";
 const char * WS_STR_ORIGIN = "Origin";
+const char * WS_STR_COOKIE = "Cookie";
 const char * WS_STR_VERSION = "Sec-WebSocket-Version";
 const char * WS_STR_KEY = "Sec-WebSocket-Key";
 const char * WS_STR_PROTOCOL = "Sec-WebSocket-Protocol";
@@ -1175,6 +1176,7 @@ bool AsyncWebSocket::canHandle(AsyncWebServerRequest *request){
   request->addInterestingHeader(WS_STR_CONNECTION);
   request->addInterestingHeader(WS_STR_UPGRADE);
   request->addInterestingHeader(WS_STR_ORIGIN);
+  request->addInterestingHeader(WS_STR_COOKIE);
   request->addInterestingHeader(WS_STR_VERSION);
   request->addInterestingHeader(WS_STR_KEY);
   request->addInterestingHeader(WS_STR_PROTOCOL);

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -237,6 +237,7 @@ class AsyncWebSocketClient {
     void _onData(void *pbuf, size_t plen);
 };
 
+typedef std::function<bool(AsyncWebServerRequest *request)> AwsHandshakeHandlerFunction;
 typedef std::function<void(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventType type, void * arg, uint8_t *data, size_t len)> AwsEventHandler;
 
 //WebServer Handler implementation that plays the role of a socket server
@@ -248,6 +249,7 @@ class AsyncWebSocket: public AsyncWebHandler {
     AsyncWebSocketClientLinkedList _clients;
     uint32_t _cNextId;
     AwsEventHandler _eventHandler;
+    AwsHandshakeHandlerFunction _handshakecb;
     bool _enabled;
     AsyncWebLock _lock;
 

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -237,7 +237,7 @@ class AsyncWebSocketClient {
     void _onData(void *pbuf, size_t plen);
 };
 
-typedef std::function<bool(AsyncWebServerRequest *request)> AwsHandshakeHandlerFunction;
+typedef std::function<bool(AsyncWebServerRequest *request)> AwsHandshakeHandler;
 typedef std::function<void(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventType type, void * arg, uint8_t *data, size_t len)> AwsEventHandler;
 
 //WebServer Handler implementation that plays the role of a socket server
@@ -249,7 +249,7 @@ class AsyncWebSocket: public AsyncWebHandler {
     AsyncWebSocketClientLinkedList _clients;
     uint32_t _cNextId;
     AwsEventHandler _eventHandler;
-    AwsHandshakeHandlerFunction _handshakecb;
+    AwsHandshakeHandler _handshakeHandler;
     bool _enabled;
     AsyncWebLock _lock;
 
@@ -316,6 +316,11 @@ class AsyncWebSocket: public AsyncWebHandler {
     //event listener
     void onEvent(AwsEventHandler handler){
       _eventHandler = handler;
+    }
+  
+    // Handshake Handler
+    void handleHandshake(AwsHandshakeHandler handler){
+      _handshakeHandler = handler; 
     }
 
     //system callbacks (do not call)


### PR DESCRIPTION
Websocket Protocol has 2 main authentication schemes. Basic Authentication and Cookie Based Authentication. Therefore `Cookie` Header should be sent along the Connect Event.