### PR TITLE
CORS mode suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,8 @@ Example:
 
 ```cpp
 DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", "*");
+// if need to respond at POST application/json then Content-Type headers requires to be allowed
+DefaultHeaders::Instance().addHeader("Access-Control-Allow-Headers", "Content-Type");
 webServer.begin();
 ```
 


### PR DESCRIPTION
Suggestion ( CORS mode ) to allow Content-Type headers when need to respond on application/json posts requests, otherwise browser will generate follow error:
`Access to fetch at 'http://10.10.0.58/api' from origin 'http://localhost:3000' has been blocked by CORS policy: Request header field content-type is not allowed by Access-Control-Allow-Headers in preflight response.`