### PR TITLE
Add code getter to AsyncWebServerResponse

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -373,6 +373,7 @@ class AsyncWebServerResponse {
   public:
     AsyncWebServerResponse();
     virtual ~AsyncWebServerResponse();
+    virtual int code() const;
     virtual void setCode(int code);
     virtual void setContentLength(size_t len);
     virtual void setContentType(const String& type);

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -104,6 +104,10 @@ AsyncWebServerResponse::~AsyncWebServerResponse(){
   _headers.free();
 }
 
+int AsyncWebServerResponse::code() const {
+  return _code;
+}
+
 void AsyncWebServerResponse::setCode(int code){
   if(_state == RESPONSE_SETUP)
     _code = code;


### PR DESCRIPTION
This change adds `code` getter to AsyncWebServerResponse.

Reasoning:
This change allows implementing out of scope automatic response sender, that greatly simplifies error handling.

Notes:
Replacing virtual by inline can slightly decrease memory usage.