### PR TITLE
Add public getter for itemName.

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -214,6 +214,7 @@ class AsyncWebServerRequest {
     const String& host() const { return _host; }
     const String& contentType() const { return _contentType; }
     size_t contentLength() const { return _contentLength; }
+    const String& itemName() const { return _itemName; }
     bool multipart() const { return _isMultipart; }
     const char * methodToString() const;
     const char * requestedConnTypeToString() const;


### PR DESCRIPTION
Some applications may get use of _itemName value, like passing some value using javascript in POST.