### PR TITLE
Fix compatibility with other libraries (WiFiManager)

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -329,7 +329,7 @@ size_t AsyncEventSource::count() const {
 }
 
 bool AsyncEventSource::canHandle(AsyncWebServerRequest *request){
-  if(request->method() != HTTP_GET || !request->url().equals(_url)) {
+  if(request->method() != WebRequestMethod::HTTP_GET || !request->url().equals(_url)) {
     return false;
   }
   request->addInterestingHeader("Last-Event-ID");

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -1169,7 +1169,7 @@ bool AsyncWebSocket::canHandle(AsyncWebServerRequest *request){
   if(!_enabled)
     return false;
   
-  if(request->method() != HTTP_GET || !request->url().equals(_url) || !request->isExpectedRequestedConnType(RCT_WS))
+  if(request->method() != WebRequestMethod::HTTP_GET || !request->url().equals(_url) || !request->isExpectedRequestedConnType(RCT_WS))
     return false;
 
   request->addInterestingHeader(WS_STR_CONNECTION);

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -67,13 +67,24 @@ typedef enum {
   HTTP_HEAD    = 0b00100000,
   HTTP_OPTIONS = 0b01000000,
   HTTP_ANY     = 0b01111111,
-} WebRequestMethod;
+} WebRequestMethodCompatible;
 #endif
+
+enum class WebRequestMethod {
+  HTTP_GET     = 0b00000001,
+  HTTP_POST    = 0b00000010,
+  HTTP_DELETE  = 0b00000100,
+  HTTP_PUT     = 0b00001000,
+  HTTP_PATCH   = 0b00010000,
+  HTTP_HEAD    = 0b00100000,
+  HTTP_OPTIONS = 0b01000000,
+  HTTP_ANY     = 0b01111111,
+};
 
 //if this value is returned when asked for data, packet will not be sent and you will be asked for data again
 #define RESPONSE_TRY_AGAIN 0xFFFFFFFF
 
-typedef uint8_t WebRequestMethodComposite;
+typedef WebRequestMethod WebRequestMethodComposite;
 typedef std::function<void(void)> ArDisconnectHandler;
 
 /*

--- a/src/SPIFFSEditor.cpp
+++ b/src/SPIFFSEditor.cpp
@@ -390,7 +390,7 @@ SPIFFSEditor::SPIFFSEditor(const String& username, const String& password, const
 
 bool SPIFFSEditor::canHandle(AsyncWebServerRequest *request){
   if(request->url().equalsIgnoreCase("/edit")){
-    if(request->method() == HTTP_GET){
+    if(request->method() == WebRequestMethod::HTTP_GET){
       if(request->hasParam("list"))
         return true;
       if(request->hasParam("edit")){
@@ -420,11 +420,11 @@ bool SPIFFSEditor::canHandle(AsyncWebServerRequest *request){
       request->addInterestingHeader("If-Modified-Since");
       return true;
     }
-    else if(request->method() == HTTP_POST)
+    else if(request->method() == WebRequestMethod::HTTP_POST)
       return true;
-    else if(request->method() == HTTP_DELETE)
+    else if(request->method() == WebRequestMethod::HTTP_DELETE)
       return true;
-    else if(request->method() == HTTP_PUT)
+    else if(request->method() == WebRequestMethod::HTTP_PUT)
       return true;
 
   }
@@ -436,7 +436,7 @@ void SPIFFSEditor::handleRequest(AsyncWebServerRequest *request){
   if(_username.length() && _password.length() && !request->authenticate(_username.c_str(), _password.c_str()))
     return request->requestAuthentication();
 
-  if(request->method() == HTTP_GET){
+  if(request->method() == WebRequestMethod::HTTP_GET){
     if(request->hasParam("list")){
       String path = request->getParam("list")->value();
 #ifdef ESP32
@@ -494,18 +494,18 @@ void SPIFFSEditor::handleRequest(AsyncWebServerRequest *request){
         request->send(response);
       }
     }
-  } else if(request->method() == HTTP_DELETE){
+  } else if(request->method() == WebRequestMethod::HTTP_DELETE){
     if(request->hasParam("path", true)){
         _fs.remove(request->getParam("path", true)->value());
       request->send(200, "", "DELETE: "+request->getParam("path", true)->value());
     } else
       request->send(404);
-  } else if(request->method() == HTTP_POST){
+  } else if(request->method() == WebRequestMethod::HTTP_POST){
     if(request->hasParam("data", true, true) && _fs.exists(request->getParam("data", true, true)->value()))
       request->send(200, "", "UPLOADED: "+request->getParam("data", true, true)->value());
     else
       request->send(500);
-  } else if(request->method() == HTTP_PUT){
+  } else if(request->method() == WebRequestMethod::HTTP_PUT){
     if(request->hasParam("path", true)){
       String filename = request->getParam("path", true)->value();
       if(_fs.exists(filename)){

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -73,7 +73,7 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
     ArBodyHandlerFunction _onBody;
     bool _isRegex;
   public:
-    AsyncCallbackWebHandler() : _uri(), _method(HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL), _isRegex(false) {}
+    AsyncCallbackWebHandler() : _uri(), _method(WebRequestMethod::HTTP_ANY), _onRequest(NULL), _onUpload(NULL), _onBody(NULL), _isRegex(false) {}
     void setUri(const String& uri){ 
       _uri = uri; 
       _isRegex = uri.startsWith("^") && uri.endsWith("$");
@@ -88,7 +88,7 @@ class AsyncCallbackWebHandler: public AsyncWebHandler {
       if(!_onRequest)
         return false;
 
-      if(!(_method & request->method()))
+      if(!(static_cast<uint8_t>(_method) & static_cast<uint8_t>(request->method())))
         return false;
 
 #ifdef ASYNCWEBSERVER_REGEX

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -81,7 +81,7 @@ AsyncStaticWebHandler& AsyncStaticWebHandler::setLastModified(){
 }
 #endif
 bool AsyncStaticWebHandler::canHandle(AsyncWebServerRequest *request){
-  if(request->method() != HTTP_GET 
+  if(request->method() != WebRequestMethod::HTTP_GET 
     || !request->url().startsWith(_uri) 
     || !request->isExpectedRequestedConnType(RCT_DEFAULT, RCT_HTTP)
   ){

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -40,7 +40,7 @@ AsyncWebServerRequest::AsyncWebServerRequest(AsyncWebServer* s, AsyncClient* c)
   , _temp()
   , _parseState(0)
   , _version(0)
-  , _method(HTTP_ANY)
+  , _method(WebRequestMethod::HTTP_ANY)
   , _url()
   , _host()
   , _contentType()
@@ -260,19 +260,19 @@ bool AsyncWebServerRequest::_parseReqHead(){
   _temp = _temp.substring(index+1);
 
   if(m == "GET"){
-    _method = HTTP_GET;
+    _method = WebRequestMethod::HTTP_GET;
   } else if(m == "POST"){
-    _method = HTTP_POST;
+    _method = WebRequestMethod::HTTP_POST;
   } else if(m == "DELETE"){
-    _method = HTTP_DELETE;
+    _method = WebRequestMethod::HTTP_DELETE;
   } else if(m == "PUT"){
-    _method = HTTP_PUT;
+    _method = WebRequestMethod::HTTP_PUT;
   } else if(m == "PATCH"){
-    _method = HTTP_PATCH;
+    _method = WebRequestMethod::HTTP_PATCH;
   } else if(m == "HEAD"){
-    _method = HTTP_HEAD;
+    _method = WebRequestMethod::HTTP_HEAD;
   } else if(m == "OPTIONS"){
-    _method = HTTP_OPTIONS;
+    _method = WebRequestMethod::HTTP_OPTIONS;
   }
 
   String g = String();
@@ -977,14 +977,14 @@ String AsyncWebServerRequest::urlDecode(const String& text) const {
 
 
 const char * AsyncWebServerRequest::methodToString() const {
-  if(_method == HTTP_ANY) return "ANY";
-  else if(_method & HTTP_GET) return "GET";
-  else if(_method & HTTP_POST) return "POST";
-  else if(_method & HTTP_DELETE) return "DELETE";
-  else if(_method & HTTP_PUT) return "PUT";
-  else if(_method & HTTP_PATCH) return "PATCH";
-  else if(_method & HTTP_HEAD) return "HEAD";
-  else if(_method & HTTP_OPTIONS) return "OPTIONS";
+  if(_method == WebRequestMethod::HTTP_ANY) return "ANY";
+  else if(static_cast<uint8_t>(_method) & static_cast<uint8_t>(WebRequestMethod::HTTP_GET)) return "GET";
+  else if(static_cast<uint8_t>(_method) & static_cast<uint8_t>(WebRequestMethod::HTTP_POST)) return "POST";
+  else if(static_cast<uint8_t>(_method) & static_cast<uint8_t>(WebRequestMethod::HTTP_DELETE)) return "DELETE";
+  else if(static_cast<uint8_t>(_method) & static_cast<uint8_t>(WebRequestMethod::HTTP_PUT)) return "PUT";
+  else if(static_cast<uint8_t>(_method) & static_cast<uint8_t>(WebRequestMethod::HTTP_PATCH)) return "PATCH";
+  else if(static_cast<uint8_t>(_method) & static_cast<uint8_t>(WebRequestMethod::HTTP_HEAD)) return "HEAD";
+  else if(static_cast<uint8_t>(_method) & static_cast<uint8_t>(WebRequestMethod::HTTP_OPTIONS)) return "OPTIONS";
   return "UNKNOWN";
 }
 


### PR DESCRIPTION
I suggest once and for all to solve the problem of compatibility with third-party libraries, for example `WiFiManager`.
С++ allows to use `scoped enumerations`, what will solve the problem.

For compatibility was left `unscoped enumeration` and renamed `WebRequestMethodCompatible`.

```c++
#include <Arduino.h>

#include "WiFiManager.h"
WiFiManager wifiManager;

#define WEBSERVER_H
#include "ESPAsyncWebServer.h"

#define HTTP_CONTENT_TYPE "text/html; charset=utf-8"

AsyncWebServer server(80);

void setup(){
  Serial.begin(115200);

  wifiManager.setConfigPortalTimeout(60);
  wifiManager.autoConnect("wifi-test");

  server.on("/test/", WebRequestMethod::HTTP_GET, [](AsyncWebServerRequest *request) {
    request->send(200, HTTP_CONTENT_TYPE, "GET");
  });

  server.on("/test/", WebRequestMethod::HTTP_PUT, [](AsyncWebServerRequest *request) {
    request->send(200, HTTP_CONTENT_TYPE, "PUT");
  });

  server.on("/test/", WebRequestMethod::HTTP_POST, [](AsyncWebServerRequest *request) {
    request->send(200, HTTP_CONTENT_TYPE, "POST");
  });

  server.begin();
}

void loop(){
}
```