### PR TITLE
Redefine DYNAMIC_JSON_DOCUMENT_SIZE if not defined

### DIFF
--- a/src/AsyncJson.h
+++ b/src/AsyncJson.h
@@ -41,7 +41,9 @@
 #if ARDUINOJSON_VERSION_MAJOR == 5
   #define ARDUINOJSON_5_COMPATIBILITY
 #else
-  #define DYNAMIC_JSON_DOCUMENT_SIZE  1024
+  #ifndef DYNAMIC_JSON_DOCUMENT_SIZE
+    #define DYNAMIC_JSON_DOCUMENT_SIZE  1024
+  #endif
 #endif
 
 constexpr const char* JSON_MIMETYPE = "application/json";


### PR DESCRIPTION
By default the json doc size for AsyncJson is #define DYNAMIC_JSON_DOCUMENT_SIZE  1024.
When I want to handle a POST request with a bigger json, the AsyncWebServer is not able to handle it and I get an Http failure response from the web browser. But with this fix you can predefine a bigger json document size.