### PR TITLE
Handle edge-case in which we receive a partial WS header

### DIFF
--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -46,6 +46,8 @@
 #define DEFAULT_MAX_WS_CLIENTS 4
 #endif
 
+#define WS_MAX_HEADER_LEN 16
+
 class AsyncWebSocket;
 class AsyncWebSocketResponse;
 class AsyncWebSocketClient;
@@ -166,6 +168,8 @@ class AsyncWebSocketClient {
 
     uint8_t _pstate;
     AwsFrameInfo _pinfo;
+    uint8_t *_partialHeader;
+    uint8_t _partialHeaderLen;
 
     uint32_t _lastMessageTime;
     uint32_t _keepAlivePeriod;


### PR DESCRIPTION
Since in my use-case I use this library to send and receive lots of data at high rates I spotted a quite infrequent bug that does not occur with occasional sending/receiving.

The issue occurs when *receiving* lots of data.
Since WebSocket and TCP framing are independent it occasionally happens that the buffer passed to `AsyncWebSocketClient::_onData` is truncated. At the current state the library handles the case in which the truncation happens mid-payload.

However, truncation may happen anywhere and it occasionally happens in the WS frame header too. This happens extremely rarely in practice, since most ESP applications predominantly send data - not receive it, and since if data is sent one frame at a time the frames are unlikely to be truncated, and if it happens it happens mid payload.

Sending lots of data increases the probability by a lot, since the frames will most likely be delivered one after the other in one big buffer; there is going to be a lot more headers and as a consequence more places where this bug could occur.

---

The fix consists in storing a partial header in the heap temporarily, then merging the remaining chunk later once it is received.

In order to do so, what used to be `uint8_t *fdata` (which I renamed to `headerBuf` for better readability) can now be either a pointer to an offset inside the input buffer or a heap-allocated buffer. The buffer is always allocated to 16 bytes, which I determined is the maximum, worst-case scenario size of the WS frame header.

The header parsing part of the code now performs the following operations (I'd like to explain the logic since the code is complex):

- If `!_pstate` (== if we're not waiting for the remaining part of a frame truncated mid-payload)
  - Set `headerBuf` to the current position in the input buffer
  - If we have a previous header stored in the heap
    - Fill the rest of it with data from the input buffer
    - Set headerBuf to this buffer
    - Clear class attribute reference to the stored header
  - Continue parsing the header the same as before, but if at any step we run out of header bytes, we jump to a handler
  - If we ran out of header bytes
    - malloc a new 16 bytes buffer
    - memcpy the current header data into it
    - Set class attribute stored header references to point to this buffer
  - If headerBuf was allocated in heap
    - Free it
  - If we ran out of header bytes
    - return

You will notice I had to use a bunch of `goto`s to handle the "failure - truncated header" scenario. It could have been a try-catch-finally, but as far as I know ESP8266 binaries are built with `-fno-exceptions`.

This code, combined with my other PR #951 was tested with Valgrind and I can claim it works very well:

![image](https://user-images.githubusercontent.com/1151321/110663082-6d2b6400-81c6-11eb-9d53-6174d7704640.png)
![image](https://user-images.githubusercontent.com/1151321/110663112-71578180-81c6-11eb-95db-2f2bca374a81.png)

