### PR TITLE
extension of response options by supporting a stateful response implementation

### DIFF
--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -750,6 +750,10 @@ AsyncWebServerResponse * AsyncWebServerRequest::beginResponse(const String& cont
   return new AsyncCallbackResponse(contentType, len, callback, templateCallback);
 }
 
+AsyncWebServerResponse * AsyncWebServerRequest::beginStatefulResponse(const String& contentType, size_t len, AwsResponseDataSource* callback, AwsTemplateProcessor templateCallback){
+  return new AsyncStatefulCallbackResponse(contentType, len, callback, templateCallback);
+}
+
 AsyncWebServerResponse * AsyncWebServerRequest::beginChunkedResponse(const String& contentType, AwsResponseFiller callback, AwsTemplateProcessor templateCallback){
   if(_version)
     return new AsyncChunkedResponse(contentType, callback, templateCallback);

--- a/src/WebResponseImpl.h
+++ b/src/WebResponseImpl.h
@@ -133,4 +133,16 @@ class AsyncResponseStream: public AsyncAbstractResponse, public Print {
     using Print::write;
 };
 
+
+class AsyncStatefulCallbackResponse : public AsyncAbstractResponse {
+private:
+  AwsResponseDataSource *_content;
+  size_t _filledLength;
+
+public:
+  AsyncStatefulCallbackResponse(const String &contentType, size_t len, AwsResponseDataSource *dataSource, AwsTemplateProcessor templateCallback = nullptr);
+  ~AsyncStatefulCallbackResponse();
+  bool _sourceValid() const { return true; }
+  virtual size_t _fillBuffer(uint8_t *buf, size_t maxLen) override;
+};
 #endif /* ASYNCWEBSERVERRESPONSEIMPL_H_ */

--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -697,3 +697,31 @@ size_t AsyncResponseStream::write(const uint8_t *data, size_t len){
 size_t AsyncResponseStream::write(uint8_t data){
   return write(&data, 1);
 }
+
+
+
+/*
+ * Stateful callback response
+ */
+
+AsyncStatefulCallbackResponse::AsyncStatefulCallbackResponse(const String &contentType, size_t len, AwsResponseDataSource *dataSource, AwsTemplateProcessor templateCallback): AsyncAbstractResponse(templateCallback) {
+  _code = 200;
+  _content=dataSource;
+  _contentLength = len;
+  if(!len)
+    _sendContentLength = false;
+  _contentType = contentType;
+  _filledLength = 0;
+}
+
+size_t AsyncStatefulCallbackResponse::_fillBuffer(uint8_t *data, size_t len){
+  size_t ret = _content->fillBuffer(data, len, _filledLength);
+  if(ret != RESPONSE_TRY_AGAIN){
+      _filledLength += ret;
+  }
+  return ret;
+}
+;
+AsyncStatefulCallbackResponse::~AsyncStatefulCallbackResponse() {
+  delete _content;
+}


### PR DESCRIPTION
Implemented a datasource-interface reflecting the lifecycle of the response, thus enabling filtering of response data from (stream/file/progmem/buffer/whatever).
Intended so solve Issue #954, and might also be a solution approch for that old discussion of #199.

Has been successfully tested with the sample code from README.md.
I am not sure if handling with HTTP/1.0 will be ok, have adapted from the existing implementation to take respect of that.
Example of more sophisticated usage will soon be available at https://github.com/makerMcl/universalUi/blob/master/webUiGenericPlaceHolder.h

I would be very grateful if you could check and accept this humble contribution.
