### PR TITLE
Use predefined WS_MAX_QUEUED_MESSAGES if valid

### DIFF
--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -24,10 +24,16 @@
 #include <Arduino.h>
 #ifdef ESP32
 #include <AsyncTCP.h>
+#if !defined(WS_MAX_QUEUED_MESSAGES) || WS_MAX_QUEUED_MESSAGES < 1
+#undef WS_MAX_QUEUED_MESSAGES
 #define WS_MAX_QUEUED_MESSAGES 32
+#endif // !defined(WS_MAX_QUEUED_MESSAGES) || WS_MAX_QUEUED_MESSAGES < 1
 #else
 #include <ESPAsyncTCP.h>
+#if !defined(WS_MAX_QUEUED_MESSAGES) || WS_MAX_QUEUED_MESSAGES < 1
+#undef WS_MAX_QUEUED_MESSAGES
 #define WS_MAX_QUEUED_MESSAGES 8
+#endif // !defined(WS_MAX_QUEUED_MESSAGES) || WS_MAX_QUEUED_MESSAGES < 1
 #endif
 #include <ESPAsyncWebServer.h>
 


### PR DESCRIPTION
If `WS_MAX_QUEUED_MESSAGES` is defined and > 0, use it. Otherwise, redefine it with the default. Some users might find this cleaner than editing the source files.