### PR TITLE
Fix build when using latest arduino-esp32 master due to IDF update

### DIFF
--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -24,18 +24,7 @@
 #include <libb64/cencode.h>
 
 #ifndef ESP8266
-extern "C" {
-typedef struct {
-    uint32_t state[5];
-    uint32_t count[2];
-    unsigned char buffer[64];
-} SHA1_CTX;
-
-void SHA1Transform(uint32_t state[5], const unsigned char buffer[64]);
-void SHA1Init(SHA1_CTX* context);
-void SHA1Update(SHA1_CTX* context, const unsigned char* data, uint32_t len);
-void SHA1Final(unsigned char digest[20], SHA1_CTX* context);
-}
+#include "mbedtls/sha1.h"
 #else
 #include <Hash.h>
 #endif
@@ -1268,10 +1257,12 @@ AsyncWebSocketResponse::AsyncWebSocketResponse(const String& key, AsyncWebSocket
   sha1(key + WS_STR_UUID, hash);
 #else
   (String&)key += WS_STR_UUID;
-  SHA1_CTX ctx;
-  SHA1Init(&ctx);
-  SHA1Update(&ctx, (const unsigned char*)key.c_str(), key.length());
-  SHA1Final(hash, &ctx);
+  mbedtls_sha1_context ctx;
+  mbedtls_sha1_init(&ctx);
+  mbedtls_sha1_starts_ret(&ctx);
+  mbedtls_sha1_update_ret(&ctx, (const unsigned char*)key.c_str(), key.length());
+  mbedtls_sha1_finish_ret(&ctx, hash);
+  mbedtls_sha1_free(&ctx);
 #endif
   base64_encodestate _state;
   base64_init_encodestate(&_state);

--- a/src/WebAuthentication.cpp
+++ b/src/WebAuthentication.cpp
@@ -71,9 +71,9 @@ static bool getMD5(uint8_t * data, uint16_t len, char * output){//33 bytes or mo
   memset(_buf, 0x00, 16);
 #ifdef ESP32
   mbedtls_md5_init(&_ctx);
-  mbedtls_md5_starts(&_ctx);
-  mbedtls_md5_update(&_ctx, data, len);
-  mbedtls_md5_finish(&_ctx, _buf);
+  mbedtls_md5_starts_ret(&_ctx);
+  mbedtls_md5_update_ret(&_ctx, data, len);
+  mbedtls_md5_finish_ret(&_ctx, _buf);
 #else
   MD5Init(&_ctx);
   MD5Update(&_ctx, data, len);


### PR DESCRIPTION
Latest idf update on arduino-esp32 (https://github.com/espressif/arduino-esp32/commit/a618fc1361b08aa968407dd81b7b065cca207f46) causes a linker failure.

This change was also applied to the original arduino-esp32 webserver.

```

Linking everything together...
d:/david/development/arduino/sketch/hardware/espressif/esp32/tools/xtensa-esp32-elf/bin/../lib/gcc/xtensa-esp32-elf/8.4.0/../../../../xtensa-esp32-elf/bin/ld.exe: C:\Users\david\AppData\Local\Temp\arduino_build_567038\libraries\ESPAsyncWebServer\WebAuthentication.cpp.o:(.literal._ZL6getMD5PhtPc+0x4): undefined reference to `mbedtls_md5_starts'
d:/david/development/arduino/sketch/hardware/espressif/esp32/tools/xtensa-esp32-elf/bin/../lib/gcc/xtensa-esp32-elf/8.4.0/../../../../xtensa-esp32-elf/bin/ld.exe: C:\Users\david\AppData\Local\Temp\arduino_build_567038\libraries\ESPAsyncWebServer\WebAuthentication.cpp.o: in function `getMD5(unsigned char*, unsigned short, char*)':
D:\david\Development\Arduino\Sketch\libraries\ESPAsyncWebServer\src/WebAuthentication.cpp:73: undefined reference to `mbedtls_md5_starts'
collect2.exe: error: ld returned 1 exit status
exit status 1
Error compiling for board ESP32 Dev Module.
```