### PR TITLE
fix: basic auth fail with admin/12345

### DIFF
--- a/src/WebAuthentication.cpp
+++ b/src/WebAuthentication.cpp
@@ -35,7 +35,7 @@ bool checkBasicAuthentication(const char * hash, const char * username, const ch
 
   size_t toencodeLen = strlen(username)+strlen(password)+1;
   size_t encodedLen = base64_encode_expected_len(toencodeLen);
-  if(strlen(hash) != encodedLen)
+  if(strlen(hash) > encodedLen)
     return false;
 
   char *toencode = new char[toencodeLen+1];


### PR DESCRIPTION
Use admin as the username and 12345 as the password for basic auth will fail.

Cause:

The calculated required bytes for base64 encoding is not equals the actual encoded results in every condition.

ref: <https://stackoverflow.com/questions/13378815/base64-length-calculation>