### PR TITLE
Fix for issue #1039. serveStatic does not work.

### DIFF
--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -37,7 +37,7 @@ class AsyncStaticWebHandler: public AsyncWebHandler {
     bool _fileExists(AsyncWebServerRequest *request, const String& path);
     uint8_t _countBits(const uint8_t value) const;
   protected:
-    FS _fs;
+    FS &_fs;
     String _uri;
     String _path;
     String _default_file;


### PR DESCRIPTION
Passing _fs by value will make a copy of fs::FS object, instead of using existing SPIFFS object.