### PR TITLE
Allow bind to specific ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ To use this library you might need to have the latest git versions of [ESP32](ht
     - [Async WebSocket Event](#async-websocket-event)
     - [Methods for sending data to a socket client](#methods-for-sending-data-to-a-socket-client)
     - [Direct access to web socket message buffer](#direct-access-to-web-socket-message-buffer)
+    - [Limiting the number of web socket clients](#limiting-the-number-of-web-socket-clients)
   - [Async Event Source Plugin](#async-event-source-plugin)
     - [Setup Event Source on the server](#setup-event-source-on-the-server)
     - [Setup Event Source in the browser](#setup-event-source-in-the-browser)
@@ -1125,6 +1126,16 @@ void sendDataWs(AsyncWebSocketClient * client)
     }
 }
 ```
+
+### Limiting the number of web socket clients
+Browsers sometimes do not correctly close the websocket connection, even when the close() function is called in javascript.  This will eventually exhaust the web server's resources and will cause the server to crash.  Periodically calling the cleanClients() function from the main loop() function limits the number of clients by closing the oldest client when the maximum number of clients has been exceeded.  This can called be every cycle, however, if you wish to use less power, then calling as infrequently as once per second is sufficient.
+
+```cpp
+void loop(){
+  ws.cleanupClients();
+}
+```
+
 
 ## Async Event Source Plugin
 The server includes EventSource (Server-Sent Events) plugin which can be used to send short text events to the browser.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# ESPAsyncWebServer [![Build Status](https://travis-ci.org/me-no-dev/ESPAsyncWebServer.svg?branch=master)](https://travis-ci.org/me-no-dev/ESPAsyncWebServer) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/395dd42cfc674e6ca2e326af3af80ffc)](https://www.codacy.com/manual/me-no-dev/ESPAsyncWebServer?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=me-no-dev/ESPAsyncWebServer&amp;utm_campaign=Badge_Grade)
+# ESPAsyncWebServer 
+[![Build Status](https://travis-ci.org/me-no-dev/ESPAsyncWebServer.svg?branch=master)](https://travis-ci.org/me-no-dev/ESPAsyncWebServer) ![](https://github.com/me-no-dev/ESPAsyncWebServer/workflows/ESP%20Async%20Web%20Server%20CI/badge.svg) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/395dd42cfc674e6ca2e326af3af80ffc)](https://www.codacy.com/manual/me-no-dev/ESPAsyncWebServer?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=me-no-dev/ESPAsyncWebServer&amp;utm_campaign=Badge_Grade)
 
 For help and support [![Join the chat at https://gitter.im/me-no-dev/ESPAsyncWebServer](https://badges.gitter.im/me-no-dev/ESPAsyncWebServer.svg)](https://gitter.im/me-no-dev/ESPAsyncWebServer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ESPAsyncWebServer 
+# ESPAsyncWebServer (Aircoookie Fork for WLED)
 [![Build Status](https://travis-ci.org/me-no-dev/ESPAsyncWebServer.svg?branch=master)](https://travis-ci.org/me-no-dev/ESPAsyncWebServer) ![](https://github.com/me-no-dev/ESPAsyncWebServer/workflows/ESP%20Async%20Web%20Server%20CI/badge.svg) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/395dd42cfc674e6ca2e326af3af80ffc)](https://www.codacy.com/manual/me-no-dev/ESPAsyncWebServer?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=me-no-dev/ESPAsyncWebServer&amp;utm_campaign=Badge_Grade)
 
 For help and support [![Join the chat at https://gitter.im/me-no-dev/ESPAsyncWebServer](https://badges.gitter.im/me-no-dev/ESPAsyncWebServer.svg)](https://gitter.im/me-no-dev/ESPAsyncWebServer?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
+++ b/examples/ESP_AsyncFSBrowser/ESP_AsyncFSBrowser.ino
@@ -217,4 +217,5 @@ void setup(){
 
 void loop(){
   ArduinoOTA.handle();
+  ws.cleanupClients();
 }

--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "https://github.com/me-no-dev/ESPAsyncWebServer.git"
   },
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "LGPL-3.0",
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"],

--- a/library.json
+++ b/library.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "https://github.com/me-no-dev/ESPAsyncWebServer.git"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "LGPL-3.0",
   "frameworks": "arduino",
   "platforms": ["espressif8266", "espressif32"],

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP Async WebServer
-version=2.0.0
+version=2.0.1
 author=Me-No-Dev
 maintainer=Me-No-Dev
 sentence=Async Web Server for ESP8266 and ESP31B (Aircoookie fork)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP Async WebServer
-version=2.0.1
+version=2.0.2
 author=Me-No-Dev
 maintainer=Me-No-Dev
 sentence=Async Web Server for ESP8266 and ESP31B (Aircoookie fork)

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -927,6 +927,13 @@ void AsyncWebSocket::closeAll(uint16_t code, const char * message){
   }
 }
 
+void AsyncWebSocket::cleanupClients(uint16_t maxClients)
+{
+  if (count() > maxClients){
+    _clients.front()->close();
+  }
+}
+
 void AsyncWebSocket::ping(uint32_t id, uint8_t *data, size_t len){
   AsyncWebSocketClient * c = client(id);
   if(c)

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -549,6 +549,11 @@ bool AsyncWebSocketClient::queueIsFull(){
   return false;
 }
 
+//Added by Aircoookie for WLED
+uint16_t AsyncWebSocketClient::queueLength(){
+  return _messageQueue.length();
+}
+
 void AsyncWebSocketClient::_queueMessage(AsyncWebSocketMessage *dataMessage){
   if(dataMessage == NULL)
     return;

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -37,6 +37,12 @@
 #include <Hash.h>
 #endif
 
+#ifdef ESP32
+#define DEFAULT_MAX_WS_CLIENTS 8
+#else
+#define DEFAULT_MAX_WS_CLIENTS 4
+#endif
+
 class AsyncWebSocket;
 class AsyncWebSocketResponse;
 class AsyncWebSocketClient;
@@ -255,6 +261,7 @@ class AsyncWebSocket: public AsyncWebHandler {
 
     void close(uint32_t id, uint16_t code=0, const char * message=NULL);
     void closeAll(uint16_t code=0, const char * message=NULL);
+    void cleanupClients(uint16_t maxClients = DEFAULT_MAX_WS_CLIENTS);
 
     void ping(uint32_t id, uint8_t *data=NULL, size_t len=0);
     void pingAll(uint8_t *data=NULL, size_t len=0); //  done

--- a/src/AsyncWebSocket.h
+++ b/src/AsyncWebSocket.h
@@ -202,6 +202,7 @@ class AsyncWebSocketClient {
     //data packets
     void message(AsyncWebSocketMessage *message){ _queueMessage(message); }
     bool queueIsFull();
+    uint16_t queueLength();
 
     size_t printf(const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
 #ifndef ESP32

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -391,6 +391,7 @@ class AsyncWebServer {
     AsyncCallbackWebHandler* _catchAllHandler;
 
   public:
+    AsyncWebServer(IPAddress addr, uint16_t port);
     AsyncWebServer(uint16_t port);
     ~AsyncWebServer();
 

--- a/src/SPIFFSEditor.h
+++ b/src/SPIFFSEditor.h
@@ -1,6 +1,7 @@
 #ifndef SPIFFSEditor_H_
 #define SPIFFSEditor_H_
 #include <ESPAsyncWebServer.h>
+#include <LittleFS.h>
 
 //this indicates that this implementation will not serve the wsec.json file from FS
 #define SPIFFS_EDITOR_AIRCOOOKIE
@@ -16,7 +17,7 @@ class SPIFFSEditor: public AsyncWebHandler {
 #ifdef ESP32
     SPIFFSEditor(const fs::FS& fs, const String& username=String(), const String& password=String());
 #else
-    SPIFFSEditor(const String& username=String(), const String& password=String(), const fs::FS& fs=SPIFFS);
+    SPIFFSEditor(const String& username=String(), const String& password=String(), const fs::FS& fs=LittleFS);
 #endif
     virtual bool canHandle(AsyncWebServerRequest *request) override final;
     virtual void handleRequest(AsyncWebServerRequest *request) override final;

--- a/src/SPIFFSEditor.h
+++ b/src/SPIFFSEditor.h
@@ -1,7 +1,9 @@
 #ifndef SPIFFSEditor_H_
 #define SPIFFSEditor_H_
 #include <ESPAsyncWebServer.h>
+#ifdef ESP8266
 #include <LittleFS.h>
+#endif
 
 //this indicates that this implementation will not serve the wsec.json file from FS
 #define SPIFFS_EDITOR_AIRCOOOKIE

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -29,9 +29,13 @@ bool ON_AP_FILTER(AsyncWebServerRequest *request) {
   return WiFi.localIP() != request->client()->localIP();
 }
 
-
 AsyncWebServer::AsyncWebServer(uint16_t port)
-  : _server(port)
+  : AsyncWebServer(IPADDR_ANY, port)
+{
+}
+
+AsyncWebServer::AsyncWebServer(IPAddress addr, uint16_t port)
+  : _server(addr, port)
   , _rewrites(LinkedList<AsyncWebRewrite*>([](AsyncWebRewrite* r){ delete r; }))
   , _handlers(LinkedList<AsyncWebHandler*>([](AsyncWebHandler* h){ delete h; }))
 {


### PR DESCRIPTION
This PR adds the ability to initialize the web server with a specific IP address. This can be useful on ESP32 where there is an ethernet hat like the QuinLED-ESP32 https://quinled.info/quinled-esp32-ethernet/   This issue was raised in issue https://github.com/Aircoookie/WLED/issues/2242