### PR TITLE
Add FS and WiFi builtin libs as dependencies

### DIFF
--- a/library.json
+++ b/library.json
@@ -18,6 +18,14 @@
   "platforms": ["espressif8266", "espressif32"],
   "dependencies": [
     {
+      "name": "FS",
+      "platforms": "espressif32"
+    },
+    {
+      "name": "WiFi",
+      "platforms": "espressif32"
+    },
+    {
       "name": "ESPAsyncTCP",
       "platforms": "espressif8266"
     },


### PR DESCRIPTION
This was failing to compile on a recent version of pio because it couldn't find references for FS.h and WiFi.h, adding these builtin libs as dependencies fixed the issue.

I'm using an ESP32, and am not sure if the same issue exists on ESP8266.