### PR TITLE
AsyncJson : Fix handling of Content-Type that end with charset

### DIFF
--- a/src/AsyncJson.h
+++ b/src/AsyncJson.h
@@ -205,7 +205,7 @@ public:
     if(_uri.length() && (_uri != request->url() && !request->url().startsWith(_uri+"/")))
       return false;
 
-    if ( !request->contentType().equalsIgnoreCase(JSON_MIMETYPE) )
+    if ( !request->contentType().substring(0, strlen(JSON_MIMETYPE)).equalsIgnoreCase(JSON_MIMETYPE) )
       return false;
 
     request->addInterestingHeader("ANY");


### PR DESCRIPTION
Like in #1084
AsyncCallbackJsonWebHandler::canHandle() doesn't work if Content-Type contains 
`application/json; charset=utf-8`
which is an eligible one for AsyncJson.

This solution is simpler to read but create a little heap consumption.
@me-no-dev : Could you choose between both solution.
Thanks you