### PR TITLE
Overload handling: low heap and number of open connecions

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,6 +829,12 @@ with "If-Modified-Since" header with the same value, instead of responding with 
 // Update the date modified string every time files are updated
 server.serveStatic("/", SPIFFS, "/www/").setLastModified("Mon, 20 Jun 2016 14:00:00 GMT");
 
+or:
+
+AsyncStaticWebHandler& handler = server.serveStatic("/", LittleFS, "/", "public, max-age=604800");
+handler.setDefaultFile("index.html");
+handler.setLastModified((const char*)"Fri, 21 Jan 2022 14:00:00 GMT");  
+
 //*** Chage last modified value at a later stage ***
 
 // During setup - read last modified value from config or EEPROM

--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -408,6 +408,7 @@ class AsyncWebServer {
     void begin();
     void end();
 
+    int numOfRequests = 0;
 #if ASYNC_TCP_SSL_ENABLED
     void onSslFileRequest(AcSSlFileHandler cb, void* arg);
     void beginSecure(const char *cert, const char *private_key_file, const char *password);
@@ -436,6 +437,7 @@ class AsyncWebServer {
     void _handleDisconnect(AsyncWebServerRequest *request);
     void _attachHandler(AsyncWebServerRequest *request);
     void _rewriteRequest(AsyncWebServerRequest *request);
+    void _freeClient(AsyncClient* c);
 };
 
 class DefaultHeaders {

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -75,6 +75,7 @@ AsyncWebServerRequest::AsyncWebServerRequest(AsyncWebServer* s, AsyncClient* c)
   c->onTimeout([](void *r, AsyncClient* c, uint32_t time){ (void)c; AsyncWebServerRequest *req = (AsyncWebServerRequest*)r; req->_onTimeout(time); }, this);
   c->onData([](void *r, AsyncClient* c, void *buf, size_t len){ (void)c; AsyncWebServerRequest *req = (AsyncWebServerRequest*)r; req->_onData(buf, len); }, this);
   c->onPoll([](void *r, AsyncClient* c){ (void)c; AsyncWebServerRequest *req = ( AsyncWebServerRequest*)r; req->_onPoll(); }, this);
+  _server->numOfRequests++;
 }
 
 AsyncWebServerRequest::~AsyncWebServerRequest(){
@@ -96,6 +97,8 @@ AsyncWebServerRequest::~AsyncWebServerRequest(){
   if(_tempFile){
     _tempFile.close();
   }
+  
+  if(_server->numOfRequests>0) _server->numOfRequests--;
 }
 
 void AsyncWebServerRequest::_onData(void *buf, size_t len){

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -21,6 +21,10 @@
 #include "ESPAsyncWebServer.h"
 #include "WebHandlerImpl.h"
 
+#define SERVER_FREE_HEAP_LEVEL_CRITICAL (5*1024)
+#define SERVER_FREE_HEAP_LEVEL_HIGH (7*1024)
+#define MAX_NUM_OF_HTTP_REQUESTS 3
+
 bool ON_STA_FILTER(AsyncWebServerRequest *request) {
   return WiFi.localIP() == request->client()->localIP();
 }
@@ -28,7 +32,6 @@ bool ON_STA_FILTER(AsyncWebServerRequest *request) {
 bool ON_AP_FILTER(AsyncWebServerRequest *request) {
   return WiFi.localIP() != request->client()->localIP();
 }
-
 
 AsyncWebServer::AsyncWebServer(uint16_t port)
   : _server(port)
@@ -41,13 +44,39 @@ AsyncWebServer::AsyncWebServer(uint16_t port)
   _server.onClient([](void *s, AsyncClient* c){
     if(c == NULL)
       return;
-    c->setRxTimeout(3);
-    AsyncWebServerRequest *r = new AsyncWebServerRequest((AsyncWebServer*)s, c);
-    if(r == NULL){
-      c->close(true);
-      c->free();
-      delete c;
+
+    AsyncWebServer* svr = (AsyncWebServer*)s;
+    int freeHeap = ESP.getFreeHeap();
+
+    if ( freeHeap < SERVER_FREE_HEAP_LEVEL_CRITICAL ){
+      svr->_freeClient(c);
+      return;
     }
+
+    c->setRxTimeout(3);
+
+    AsyncWebServerRequest *r = new AsyncWebServerRequest(svr, c);
+    if(r == NULL){
+      svr->_freeClient(c);
+      return;
+    }
+
+    if ( freeHeap < SERVER_FREE_HEAP_LEVEL_HIGH ){
+      r->send(500);
+      return;
+    }
+
+    if(svr->numOfRequests > MAX_NUM_OF_HTTP_REQUESTS){
+      AsyncWebServerResponse *response = r->beginResponse(429);
+
+      if(!response){
+        svr->_freeClient(c);
+        return;
+      } 
+
+      response->addHeader("Retry-After", "1");
+      r->send(response);
+    } 
   }, this);
 }
 
@@ -123,6 +152,11 @@ void AsyncWebServer::_attachHandler(AsyncWebServerRequest *request){
   request->setHandler(_catchAllHandler);
 }
 
+void AsyncWebServer::_freeClient(AsyncClient* c){
+      c->close(true);
+      c->free();
+      delete c;
+}
 
 AsyncCallbackWebHandler& AsyncWebServer::on(const char* uri, WebRequestMethodComposite method, ArRequestHandlerFunction onRequest, ArUploadHandlerFunction onUpload, ArBodyHandlerFunction onBody){
   AsyncCallbackWebHandler* handler = new AsyncCallbackWebHandler();


### PR DESCRIPTION
Stability improvements to the server, allowing to survive momentary overload e.g. when serving more the 4 files on handling a few clients.

Overload control thresholds:
Level1: (max connections exceeded): send 429 with header "Retry-After" set to 1 second
Level2: (low free Heep): send pure 500 (no extra info added into reponse header)
Level3: (very low free help or if can not create AsyncWebServerRequest object - request too big): immediate drop underlying TCP connection

It's been tested on ESP8266. All above strategies looks to work well. Client (web browser) re-tries http request after getting 429 or 500. This allows to serve html projects with more than ~4 (html/CSS/js/...) files being requested simultaneously on ESP8266 (10 files in my case). Closing connection causes a web browser to finish loading the webpage without waiting forever for a request which has been shed due to the overload.

Overall: an application started to work stable now :) No spurious resets even after 1 day and while working with 8 browsers connected and running an application (web API calls every 1 sec from each browser in parallel with loading webpage's body from other clients).

ESP32: MAX_NUM_OF_HTTP_REQUESTS - this may likely be set higher (more RAM just for the server), but I was not testing this no ESP32.

