### PR TITLE
Fix macro invocation with post-increment index as argument

### DIFF
--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -28,7 +28,14 @@
 
 static const String SharedEmptyString = String();
 
-#define __is_param_char(c) ((c) && ((c) != '{') && ((c) != '[') && ((c) != '&') && ((c) != '='))
+bool is_param_char(char c) {
+  return 
+	(c != 0) && 
+	(c != '{') && 
+	(c != '[') && 
+	(c != '&') && 
+	(c != '=');
+}
 
 enum { PARSE_REQ_START, PARSE_REQ_HEADERS, PARSE_REQ_BODY, PARSE_REQ_END, PARSE_REQ_FAIL };
 
@@ -145,14 +152,9 @@ void AsyncWebServerRequest::_onData(void *buf, size_t len){
       if(_parsedLength == 0){
         if(_contentType.startsWith("application/x-www-form-urlencoded")){
           _isPlainPost = true;
-        } else if(_contentType == "text/plain" && __is_param_char(((char*)buf)[0])){
+        } else if(_contentType == "text/plain" && is_param_char(((char*)buf)[0])){
           size_t i = 0;
-          while (i<len)
-          {
-            auto data = ((char*)buf)[i++];
-            if( !__is_param_char(data) )
-              break;
-          }
+	  while (i<len && is_param_char(((char*)buf)[i++]));
           if(i < len && ((char*)buf)[i-1] == '='){
             _isPlainPost = true;
           }


### PR DESCRIPTION
In WebRequest.cpp at line 150:
`while (i<len && __is_param_char(((char*)buf)[i++]));`
the macro `__is_param_char` will expand producing multiple `i++` invocations making the algorithm to (sometimes) fail.