### PR TITLE
Added Content Type .svgz to responses with proper content encoding ap…

### DIFF
--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -493,6 +493,10 @@ void AsyncFileResponse::_setContentType(const String& path){
   else if (path.endsWith(".jpg")) _contentType = "image/jpeg";
   else if (path.endsWith(".ico")) _contentType = "image/x-icon";
   else if (path.endsWith(".svg")) _contentType = "image/svg+xml";
+  else if (path.endsWith(".svgz")){
+    _contentType = "image/svg+xml";
+    addHeader("Content-Encoding", "gzip");
+  }
   else if (path.endsWith(".eot")) _contentType = "font/eot";
   else if (path.endsWith(".woff")) _contentType = "font/woff";
   else if (path.endsWith(".woff2")) _contentType = "font/woff2";


### PR DESCRIPTION
Needed to conserve space on ESP32 but needed to serve svg files so when I tried to use svgz they were not properly served. Could not find any solution so I added a content type and encoding to the responses. 