### PR TITLE
Fix sending of bare (no data field) SSE events

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -56,7 +56,7 @@ static String generateEventMessage(const char *message, const char *event, uint3
           ldata[llen] = 0;
           ev += "data: ";
           ev += ldata;
-          ev += "\r\n\r\n";
+          ev += "\r\n";
           free(ldata);
         }
         lineStart = (char *)message + messageLen;
@@ -101,6 +101,7 @@ static String generateEventMessage(const char *message, const char *event, uint3
     } while(lineStart < ((char *)message + messageLen));
   }
 
+  ev += "\r\n";
   return ev;
 }
 


### PR DESCRIPTION
When doing things like `events->send(NULL, "foo");` the text in the stream is missing the event's final CRLF, so browsers think multiple events are actually one big event.

This PR fixes that by moving the final CRLF outside of `if(message != NULL)`.
