### PR TITLE
ESP32: Use path() instead of name() to keep '/' before filename (#1210)

### DIFF
--- a/src/SPIFFSEditor.cpp
+++ b/src/SPIFFSEditor.cpp
@@ -463,7 +463,11 @@ void SPIFFSEditor::handleRequest(AsyncWebServerRequest *request){
         output += "{\"type\":\"";
         output += "file";
         output += "\",\"name\":\"";
+#ifdef ESP32
+        output += String(entry.path());
+#else
         output += String(entry.name());
+#endif
         output += "\",\"size\":";
         output += String(entry.size());
         output += "}";


### PR DESCRIPTION
The leading slashes were missing in SPIFFSEditor file overview. Therefore any requests to open, save, delete, etc. didn't work (seems to be introduced with new LittleFS implementation on current Arduino core).
Using `path()` instead of `name()` keeps the slash in front of the filename and fixes the errors.

See additional details in #1210.