### PR TITLE
add support for brotli compressed files

### DIFF
--- a/src/ESPAsyncWebServer.h
+++ b/src/ESPAsyncWebServer.h
@@ -46,6 +46,14 @@
 
 #define DEBUGF(...) //Serial.printf(__VA_ARGS__)
 
+// const strings
+static const char c_gzip[] = "gzip";
+static const char c_brotli[] = "br";
+static const char c_gz[] = ".gz";
+static const char c_br[] = ".br";
+static const char c_cencoding[] = "Content-Encoding";
+static const char c_cdisposition[] = "Content-Disposition";
+
 class AsyncWebServer;
 class AsyncWebServerRequest;
 class AsyncWebServerResponse;

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -138,26 +138,38 @@ bool AsyncStaticWebHandler::_fileExists(AsyncWebServerRequest *request, const St
 {
   bool fileFound = false;
   bool gzipFound = false;
+  bool brotliFound = false;
 
-  String gzip = path + ".gz";
+  String gzip(path);
+  gzip += c_gz;
+  String brotli(path);
+  brotli += c_br;
 
   if (_gzipFirst) {
-    request->_tempFile = _fs.open(gzip, "r");
-    gzipFound = FILE_IS_REAL(request->_tempFile);
-    if (!gzipFound){
-      request->_tempFile = _fs.open(path, "r");
-      fileFound = FILE_IS_REAL(request->_tempFile);
+    request->_tempFile = _fs.open(brotli, "r");
+    brotliFound = FILE_IS_REAL(request->_tempFile);
+    if (!brotliFound){
+      request->_tempFile = _fs.open(gzip, "r");
+      gzipFound = FILE_IS_REAL(request->_tempFile);
+      if (!gzipFound){
+        request->_tempFile = _fs.open(path, "r");
+        fileFound = FILE_IS_REAL(request->_tempFile);
+      }
     }
   } else {
     request->_tempFile = _fs.open(path, "r");
     fileFound = FILE_IS_REAL(request->_tempFile);
     if (!fileFound){
-      request->_tempFile = _fs.open(gzip, "r");
-      gzipFound = FILE_IS_REAL(request->_tempFile);
+      request->_tempFile = _fs.open(brotli, "r");
+      brotliFound = FILE_IS_REAL(request->_tempFile);
+      if (!brotliFound){
+        request->_tempFile = _fs.open(gzip, "r");
+        gzipFound = FILE_IS_REAL(request->_tempFile);
+      }
     }
   }
 
-  bool found = fileFound || gzipFound;
+  bool found = fileFound || gzipFound || brotliFound;
 
   if (found) {
     // Extract the file name from the path and keep it in _tempObject


### PR DESCRIPTION
static files could be compressed with brotli and must have '.br' extension.
It works same way as with .gz files, brotli has preference if both file types are present