### PR TITLE
set real "Last-Modified" header based on file's LastWrite time

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,8 +823,11 @@ handler->setCacheControl("max-age=30");
 ```
 
 ### Specifying Date-Modified header
-It is possible to specify Date-Modified header to enable the server to return Not-Modified (304) response for requests
-with "If-Modified-Since" header with the same value, instead of responding with the actual file content.
+Sever sets "Last-Modified" header automatically if FS driver supports file modification timestamps (LittleFS does).
+Server returns "Not-Modified" (304) response for requests with "If-Modified-Since" header with _the same_ value as file's mod date, instead of responding with the actual file content. It does not perform date calculations checking if File's mod date is newer or later than in "If-Modified-Since" header.
+
+For FS not supporting file timestamps (like deprecated SPIFFS) it is possible to specify Date-Modified header manually.
+
 ```cpp
 // Update the date modified string every time files are updated
 server.serveStatic("/", SPIFFS, "/www/").setLastModified("Mon, 20 Jun 2016 14:00:00 GMT");

--- a/src/WebHandlerImpl.h
+++ b/src/WebHandlerImpl.h
@@ -28,6 +28,7 @@
 
 #include "stddef.h"
 #include <time.h>
+#include <ctime>
 
 class AsyncStaticWebHandler: public AsyncWebHandler {
    using File = fs::File;
@@ -55,7 +56,7 @@ class AsyncStaticWebHandler: public AsyncWebHandler {
     AsyncStaticWebHandler& setDefaultFile(const char* filename);
     AsyncStaticWebHandler& setCacheControl(const char* cache_control);
     AsyncStaticWebHandler& setLastModified(const char* last_modified);
-    AsyncStaticWebHandler& setLastModified(struct tm* last_modified);
+    AsyncStaticWebHandler& setLastModified(const std::tm* last_modified);
   #ifdef ESP8266
     AsyncStaticWebHandler& setLastModified(time_t last_modified);
     AsyncStaticWebHandler& setLastModified(); //sets to current time. Make sure sntp is runing and time is updated

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -208,7 +208,7 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request)
       _last_modified.concat(" GMT");
       _last_modified.setCharAt(29, 0);    // null terminate
     }
-    String etag(request->_tempFile.size());
+    String etag(lw ? lw : request->_tempFile.size());   // set etag to lastmod timestamp if available, otherwise to size
     if (_last_modified.length() && _last_modified == request->header("If-Modified-Since")) {
       request->_tempFile.close();
       request->send(304); // Not modified

--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -58,14 +58,15 @@ AsyncStaticWebHandler& AsyncStaticWebHandler::setCacheControl(const char* cache_
 }
 
 AsyncStaticWebHandler& AsyncStaticWebHandler::setLastModified(const char* last_modified){
-  _last_modified = String(last_modified);
+  _last_modified = last_modified;
   return *this;
 }
 
-AsyncStaticWebHandler& AsyncStaticWebHandler::setLastModified(struct tm* last_modified){
-  char result[30];
-  strftime (result,30,"%a, %d %b %Y %H:%M:%S %Z", last_modified);
-  return setLastModified((const char *)result);
+AsyncStaticWebHandler& AsyncStaticWebHandler::setLastModified(const std::tm* last_modified){
+  constexpr size_t buffsize = sizeof("Fri, 27 Jan 2023 15:50:27 GMT");    // a format for LM header
+  char result[buffsize];
+  std::strftime(result, buffsize, "%a, %d %b %Y %H:%M:%S GMT", last_modified);
+  return setLastModified(static_cast<const char *>(result));
 }
 
 #ifdef ESP8266
@@ -195,19 +196,7 @@ void AsyncStaticWebHandler::handleRequest(AsyncWebServerRequest *request)
 
   if (request->_tempFile == true) {
     time_t lw = request->_tempFile.getLastWrite();    // get last file mod time (if supported by FS)
-    if (lw) {
-      _last_modified.clear();
-      _last_modified.reserve(30);         // need 'Fri, 27 Jan 2023 15:50:27 GMT'
-      char *t = ctime(&lw);               // ctime 'Thu Jan 26 17:42:48 2023'
-      _last_modified.concat(t, 3);        // day of week
-      _last_modified.concat((char)0x2c);  // comma
-      _last_modified.concat(t+7, 3);      // day
-      _last_modified.concat(t+3, 4);      // month
-      _last_modified.concat(t+19, 5);     // year
-      _last_modified.concat(t+10, 9);     // time
-      _last_modified.concat(" GMT");
-      _last_modified.setCharAt(29, 0);    // null terminate
-    }
+    if (lw) setLastModified(std::gmtime(&lw));
     String etag(lw ? lw : request->_tempFile.size());   // set etag to lastmod timestamp if available, otherwise to size
     if (_last_modified.length() && _last_modified == request->header("If-Modified-Since")) {
       request->_tempFile.close();


### PR DESCRIPTION
Get file's LastWrite timestamp for file handlers (if supported by FS driver) and construct proper `Last-Modified` header. Works fine for LittleFS. If not supported by FS than fallback to previous implementation with manual setup for `Last-Modified` value.
This way caching in browsers really works as it should be for any file updates on fs.