### PR TITLE
Fix: Vulnerability in Comparison of different type sizes

### DIFF
--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -545,7 +545,7 @@ void AsyncWebServerRequest::_parseMultipartPostByte(uint8_t data, bool last){
     } else {
       _multiParseState = WAIT_FOR_RETURN1;
       itemWriteByte('\r'); itemWriteByte('\n'); itemWriteByte('-');  itemWriteByte('-');
-      uint8_t i; for(i=0; i<_boundary.length(); i++) itemWriteByte(_boundary.c_str()[i]);
+      uint32_t i; for(i=0; i<_boundary.length(); i++) itemWriteByte(_boundary.c_str()[i]);
       itemWriteByte('\r'); _parseMultipartPostByte(data, last);
     }
   }

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -535,7 +535,7 @@ void AsyncWebServerRequest::_parseMultipartPostByte(uint8_t data, bool last){
     } else {
       _multiParseState = WAIT_FOR_RETURN1;
       itemWriteByte('\r'); itemWriteByte('\n'); itemWriteByte('-');  itemWriteByte('-');
-      uint16_t i; for(i=0; i<_boundary.length(); i++) itemWriteByte(_boundary.c_str()[i]);
+      uint32_t i; for(i=0; i<_boundary.length(); i++) itemWriteByte(_boundary.c_str()[i]);
       _parseMultipartPostByte(data, last);
     }
   } else if(_multiParseState == EXPECT_FEED2){

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -535,7 +535,7 @@ void AsyncWebServerRequest::_parseMultipartPostByte(uint8_t data, bool last){
     } else {
       _multiParseState = WAIT_FOR_RETURN1;
       itemWriteByte('\r'); itemWriteByte('\n'); itemWriteByte('-');  itemWriteByte('-');
-      uint8_t i; for(i=0; i<_boundary.length(); i++) itemWriteByte(_boundary.c_str()[i]);
+      uint16_t i; for(i=0; i<_boundary.length(); i++) itemWriteByte(_boundary.c_str()[i]);
       _parseMultipartPostByte(data, last);
     }
   } else if(_multiParseState == EXPECT_FEED2){


### PR DESCRIPTION
Little change in sizes of for loop iterator "i", from uint8_t to uint32_t, to avoid possible infinite loop, which depends on the value of the comparison with "_boundary.length()".
More information in issue: https://github.com/me-no-dev/ESPAsyncWebServer/issues/1285