### PR TITLE
Fix bug where _default_file is appended to full path with filename in…

### DIFF
--- a/src/WebHandlers.cpp
+++ b/src/WebHandlers.cpp
@@ -120,6 +120,7 @@ bool AsyncStaticWebHandler::_getFile(AsyncWebServerRequest *request)
   if (_default_file.length() == 0)
     return false;
 
+  path = _path;
   // Try to add default file, ensure there is a trailing '/' ot the path.
   if (path.length() == 0 || path[path.length()-1] != '/')
     path += "/";


### PR DESCRIPTION
…stead of directory."

When using serveStatic like so:
    web_server.serveStatic("/overlays/", LittleFS, "/overlays/").setDefaultFile("notfound.html");

with notfound.html in /littlefs/overlays/

And requesting a file the does not exist like so:
host/overlays/doesnotexist.bmp

Received the following errors:
[ 13319][E][vfs_api.cpp:104] open(): /littlefs/overlays/overlays/doesnotexist.bmp does not exist, no permits for creation
[ 13327][E][vfs_api.cpp:104] open(): /littlefs/overlays/overlays/doesnotexist.bmp.gz does not exist, no permits for creation
[ 13337][E][vfs_api.cpp:104] open(): /littlefs/overlays/overlays/doesnotexist.bmp/notfound.html does not exist, no permits for creation
[ 13348][E][vfs_api.cpp:104] open(): /littlefs/overlays/overlays/doesnotexist.bmp/notfound.html.gz does not exist, no permits for creation

I tested several other of my own scenarios with serveStatic() and the examples given for serveStatic() in the documentation and the _getFile() appears to work correctly now for all cases.
