### PR TITLE
Replaced Trailing Spaces in Chunk Size with Leading Zeros

### DIFF
--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -317,8 +317,7 @@ size_t AsyncAbstractResponse::_ack(AsyncWebServerRequest *request, size_t len, u
           free(buf);
           return 0;
       }
-      outLen = sprintf((char*)buf+headLen, "%x", readLen) + headLen;
-      while(outLen < headLen + 4) buf[outLen++] = ' ';
+      outLen = sprintf((char*)buf+headLen, "%04x", readLen) + headLen;
       buf[outLen++] = '\r';
       buf[outLen++] = '\n';
       outLen += readLen;


### PR DESCRIPTION
Related to #1324

Replaced trailing spaces after chunk size with leading zeros which is in compliance with RFC.