### PR TITLE
Fix build on Arduino ESP32 v3.0.0 and IDF 5.1.1

### DIFF
--- a/src/AsyncEventSource.cpp
+++ b/src/AsyncEventSource.cpp
@@ -20,6 +20,10 @@
 #include "Arduino.h"
 #include "AsyncEventSource.h"
 
+#ifdef ESP32
+#include "rom/ets_sys.h"
+#endif
+
 static String generateEventMessage(const char *message, const char *event, uint32_t id, uint32_t reconnect){
   String ev = "";
 

--- a/src/AsyncWebSocket.cpp
+++ b/src/AsyncWebSocket.cpp
@@ -23,8 +23,9 @@
 
 #include <libb64/cencode.h>
 
-#ifndef ESP8266
+#ifdef ESP32
 #include "mbedtls/sha1.h"
+#include "rom/ets_sys.h"
 #else
 #include <Hash.h>
 #endif
@@ -829,7 +830,7 @@ void AsyncWebSocketClient::binary(AsyncWebSocketMessageBuffer * buffer)
 
 IPAddress AsyncWebSocketClient::remoteIP() {
     if(!_client) {
-        return IPAddress(0U);
+        return IPAddress(uint32_t(0));
     }
     return _client->remoteIP();
 }
@@ -1259,9 +1260,9 @@ AsyncWebSocketResponse::AsyncWebSocketResponse(const String& key, AsyncWebSocket
   (String&)key += WS_STR_UUID;
   mbedtls_sha1_context ctx;
   mbedtls_sha1_init(&ctx);
-  mbedtls_sha1_starts_ret(&ctx);
-  mbedtls_sha1_update_ret(&ctx, (const unsigned char*)key.c_str(), key.length());
-  mbedtls_sha1_finish_ret(&ctx, hash);
+  mbedtls_sha1_starts(&ctx);
+  mbedtls_sha1_update(&ctx, (const unsigned char*)key.c_str(), key.length());
+  mbedtls_sha1_finish(&ctx, hash);
   mbedtls_sha1_free(&ctx);
 #endif
   base64_encodestate _state;

--- a/src/WebAuthentication.cpp
+++ b/src/WebAuthentication.cpp
@@ -71,9 +71,9 @@ static bool getMD5(uint8_t * data, uint16_t len, char * output){//33 bytes or mo
   memset(_buf, 0x00, 16);
 #ifdef ESP32
   mbedtls_md5_init(&_ctx);
-  mbedtls_md5_starts_ret(&_ctx);
-  mbedtls_md5_update_ret(&_ctx, data, len);
-  mbedtls_md5_finish_ret(&_ctx, _buf);
+  mbedtls_md5_starts(&_ctx);
+  mbedtls_md5_update(&_ctx, data, len);
+  mbedtls_md5_finish(&_ctx, _buf);
 #else
   MD5Init(&_ctx);
   MD5Update(&_ctx, data, len);


### PR DESCRIPTION
This fixes compilation on the latest Git version of the Arduino ESP32 core due to API changes in IDF 5.1.

Of course, these changes make ESPAsyncWebServer incompatible with prior Arduino core versions.