### PR TITLE
Chunked Response broken on Safar/iOS

### DIFF
--- a/src/WebResponses.cpp
+++ b/src/WebResponses.cpp
@@ -312,13 +312,14 @@ size_t AsyncAbstractResponse::_ack(AsyncWebServerRequest *request, size_t len, u
     if(_chunked){
       // HTTP 1.1 allows leading zeros in chunk length. Or spaces may be added.
       // See RFC2616 sections 2, 3.6.1.
+      // -- OR NOT: There is nothing about spaces there, and it breaks Webkit browsers on iOS!
       readLen = _fillBufferAndProcessTemplates(buf+headLen+6, outLen - 8);
       if(readLen == RESPONSE_TRY_AGAIN){
           free(buf);
           return 0;
       }
-      outLen = sprintf((char*)buf+headLen, "%x", readLen) + headLen;
-      while(outLen < headLen + 4) buf[outLen++] = ' ';
+      outLen = sprintf((char*)buf+headLen, "%04x", readLen) + headLen;
+      // while(outLen < headLen + 4) buf[outLen++] = ' ';
       buf[outLen++] = '\r';
       buf[outLen++] = '\n';
       outLen += readLen;


### PR DESCRIPTION
Chunked responses cause Safari on iOS 18 to display "Safari can't open the page. The error was "cannot parse response"".

The reason is that the handling of chunked response is not standard conforming in the current implementation. In contrast to a comment in the source code, the standard (RFC2616) does not allow spaces between the chunk size and the crlf. Most other browsers are more tolerant in this regard, but not Safari on iOS.

There is an easy fix: As also stated in the existing comment, leading zeros are standard compliant. So it is possible to generate an equivalent, standard compliant chunked encoding that is also correctly handled by iOS by extending the size prefix not with spaces at the end, but with leading zeros. 