### PR TITLE
WebRequest.cpp modifications to prevent exception that reboot ESP32

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ To use this library you might need to have the latest git versions of [ESP8266](
 For ESP32 it requires [AsyncTCP](https://github.com/me-no-dev/AsyncTCP) to work
 To use this library you might need to have the latest git versions of [ESP32](https://github.com/espressif/arduino-esp32) Arduino Core
 
+Local modified WebRequest.cpp to prevent exception that reboots ESP32
+
 ## Table of contents
 - [ESPAsyncWebServer](#espasyncwebserver)
   - [Table of contents](#table-of-contents)

--- a/src/WebRequest.cpp
+++ b/src/WebRequest.cpp
@@ -178,13 +178,30 @@ void AsyncWebServerRequest::_onData(void *buf, size_t len){
   }
 }
 
-void AsyncWebServerRequest::_removeNotInterestingHeaders(){
-  if (_interestingHeaders.containsIgnoreCase("ANY")) return; // nothing to do
-  for(const auto& header: _headers){
-      if(!_interestingHeaders.containsIgnoreCase(header->name().c_str())){
-        _headers.remove(header);
-      }
-  }
+// Changes by Copilot
+// void AsyncWebServerRequest::_removeNotInterestingHeaders(){
+//   if (_interestingHeaders.containsIgnoreCase("ANY")) return; // nothing to do
+//   for(const auto& header: _headers){
+//       if(!_interestingHeaders.containsIgnoreCase(header->name().c_str())){
+//         _headers.remove(header);
+//       }
+//   }
+// }
+void AsyncWebServerRequest::_removeNotInterestingHeaders() {
+    if (_interestingHeaders.containsIgnoreCase("ANY")) return; // nothing to do
+
+    // Create a new container to store the headers that we want to keep
+    std::vector<AsyncWebHeader*> newHeaders;
+    for (auto& header : _headers) {
+        if (header != nullptr && _interestingHeaders.containsIgnoreCase(header->name().c_str())) {
+            newHeaders.push_back(header); // Keep this header
+        }
+    }
+    // Replace the original _headers container with the new container
+    _headers.free();
+    for (auto& header : newHeaders) {
+        _headers.add(header);
+    }
 }
 
 void AsyncWebServerRequest::_onPoll(){


### PR DESCRIPTION
WebRequest.cpp modifications to prevent exception that reboot ESP32:

In the master version, AsyncWebServerRequest::_removeNotInterestingHeaders() produce a exception in if(!_interestingHeaders.containsIgnoreCase(header->name().c_str())){ _headers.remove(header); } sentence.

Guru Meditation Error occurred due to a LoadProhibited exception. This type of error happens when the CPU tries to dereference a pointer that is either NULL or invalid.

Copilot suggested a modification in lines 181-188 of Webrequest.cpp and now it works fine.